### PR TITLE
Add release workflow and documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0] - 2026-02-04
+
+### Added
+- `Writer::from_path_buffered()` for reduced syscall overhead (#7)
+- `Writer::finish()` method for proper EOF handling
+- Compression benchmarks using Criterion
+
+### Changed
+- Optimized compression with header template and direct footer writes (#5)
+- Eliminated buffer zero-fill with unsafe resize for ~5% performance improvement (#6)
+
+### Fixed
+- Heap allocation eliminated in `header_inner()`
+
+## [0.2.0] - 2022-03-04
+
+Initial public release.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,39 @@
+# Releasing
+
+This document describes how to release a new version of bgzf.
+
+## Prerequisites
+
+1. Ensure you have push access to the repository
+2. Ensure `CARGO_REGISTRY_TOKEN` secret is configured in GitHub repository settings
+
+## Release Process
+
+1. Update `CHANGELOG.md` with the release date and any final changes
+
+2. Update version in `Cargo.toml`:
+   ```toml
+   version = "X.Y.Z"
+   ```
+
+3. Commit the version bump:
+   ```bash
+   git add Cargo.toml CHANGELOG.md
+   git commit -m "chore: release vX.Y.Z"
+   ```
+
+4. Create and push a tag:
+   ```bash
+   git tag vX.Y.Z
+   git push origin main --tags
+   ```
+
+5. The GitHub Action will automatically:
+   - Publish to crates.io
+   - Create a GitHub Release with auto-generated notes
+
+## Version Guidelines
+
+- **Major (X.0.0)**: Breaking API changes
+- **Minor (0.X.0)**: New features, deprecations
+- **Patch (0.0.X)**: Bug fixes, performance improvements


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to automate publishing to crates.io on version tags
- Add CHANGELOG.md documenting changes from v0.2.0 to v0.3.0
- Add RELEASING.md with release process documentation

## Setup Required
Add `CARGO_REGISTRY_TOKEN` secret to GitHub repository settings before the workflow can be used.

## Test plan
- [ ] Review workflow YAML for correctness
- [ ] Verify CHANGELOG accurately reflects recent changes
- [ ] Confirm RELEASING.md instructions are clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)