### PR TITLE
perf: store-only (level 0) fast paths for read and write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Store-only (compression level 0) fast paths: `Writer` emits DEFLATE stored blocks directly
+  (no libdeflate, no intermediate `BytesMut`), and `Reader` reads a single final stored block
+  straight into its decompressed buffer, bypassing libdeflate. Reading incompressible data (which
+  deflate stores even at higher levels) benefits automatically.
+- `Reader::with_crc_validation(false)` to skip per-block CRC32 verification for faster reads of
+  trusted, transient uncompressed streams (CRC validation remains on by default).
+- `CompressionLevel` now documents level 0 as "no compression" (stored blocks).
+
+### Fixed
+- Reject blocks whose footer ISIZE exceeds the maximum BGZF block size
+  (`BgzfError::UncompressedSizeExceeded`) instead of indexing past the fixed-size buffer.
+- Reject blocks smaller than a header plus footer.
+- Report a truncated trailing block as an error rather than silently treating it as end-of-input.
+- Prevent a `u16` `BSIZE` overflow in `Compressor::compress` for near-incompressible blocks
+  (previously panicked in debug / wrote a corrupt size in release).
+- Reject `blocksize == 0` in `Writer::with_capacity` (previously looped forever).
+
 ## [0.3.0] - 2026-02-04
 
 ### Added

--- a/benches/compression.rs
+++ b/benches/compression.rs
@@ -1,9 +1,46 @@
-use std::io::{BufWriter, Write};
+use std::io::{self, BufWriter, Read, Write};
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use tempfile::tempdir;
 
-use bgzf::{CompressionLevel, Compressor, Writer, BGZF_BLOCK_SIZE};
+use bgzf::{CompressionLevel, Compressor, Reader, Writer, BGZF_BLOCK_SIZE};
+
+/// Deterministic, effectively-incompressible bytes (xorshift64). Stresses the
+/// full-size `compressed_buffer` path on read, since deflate can't shrink it.
+fn incompressible(len: usize) -> Vec<u8> {
+    let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
+    let mut out = Vec::with_capacity(len + 8);
+    while out.len() < len {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        out.extend_from_slice(&state.to_le_bytes());
+    }
+    out.truncate(len);
+    out
+}
+
+/// Deterministic random ACGT bases — realistic genomic-ish data that deflate
+/// compresses ~4x, so compressed blocks are small.
+fn genomic(len: usize) -> Vec<u8> {
+    const BASES: &[u8] = b"ACGT";
+    let mut state: u64 = 0x0123_4567_89AB_CDEF;
+    let mut out = Vec::with_capacity(len);
+    while out.len() < len {
+        state = state.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+        out.push(BASES[((state >> 33) & 3) as usize]);
+    }
+    out
+}
+
+/// BGZF-compress `data` at `level` into an in-memory blob.
+fn make_bgzf(data: &[u8], level: u8) -> Vec<u8> {
+    let mut out = Vec::with_capacity(data.len());
+    let mut writer = Writer::new(&mut out, CompressionLevel::new(level).unwrap());
+    writer.write_all(data).unwrap();
+    writer.finish().unwrap();
+    out
+}
 
 fn bench_compressor_single_block(c: &mut Criterion) {
     let input = vec![b'A'; BGZF_BLOCK_SIZE];
@@ -95,11 +132,124 @@ fn bench_writer_file_io(c: &mut Criterion) {
     group.finish();
 }
 
+/// Decompress a whole in-memory BGZF blob. This is the path that carries the
+/// per-block zero-fills and `BytesMut` overhead we're trying to remove.
+fn bench_reader(c: &mut Criterion) {
+    let size = BGZF_BLOCK_SIZE * 100; // ~6.5 MB
+    let datasets = [("incompressible", incompressible(size)), ("genomic", genomic(size))];
+
+    let mut group = c.benchmark_group("reader");
+    for (name, data) in &datasets {
+        let blob = make_bgzf(data, 6);
+        group.throughput(Throughput::Bytes(data.len() as u64));
+        group.bench_function(*name, |b| {
+            b.iter(|| {
+                let mut reader = Reader::new(blob.as_slice());
+                let mut out = Vec::with_capacity(data.len());
+                reader.read_to_end(&mut out).unwrap();
+                black_box(&out);
+            })
+        });
+    }
+    group.finish();
+}
+
+/// Read a BGZF blob and re-compress it to a new blob via `io::copy` — the
+/// canonical "transcode" pipeline. Re-compresses at level 1 so deflate doesn't
+/// completely swamp the read-side copy/memset overhead.
+fn bench_roundtrip(c: &mut Criterion) {
+    let size = BGZF_BLOCK_SIZE * 100; // ~6.5 MB
+    let datasets = [("incompressible", incompressible(size)), ("genomic", genomic(size))];
+
+    let mut group = c.benchmark_group("roundtrip");
+    for (name, data) in &datasets {
+        let blob = make_bgzf(data, 6);
+        group.throughput(Throughput::Bytes(data.len() as u64));
+        group.bench_function(*name, |b| {
+            b.iter(|| {
+                let mut reader = Reader::new(blob.as_slice());
+                let mut out = Vec::with_capacity(blob.len());
+                let mut writer = Writer::new(&mut out, CompressionLevel::new(1).unwrap());
+                io::copy(&mut reader, &mut writer).unwrap();
+                writer.finish().unwrap();
+                black_box(&out);
+            })
+        });
+    }
+    group.finish();
+}
+
+/// Write store-only output (compression level 0 => DEFLATE stored blocks). This is
+/// the path the store-only write fast path targets: framing plus a verbatim copy and
+/// CRC, with no real deflate work.
+fn bench_writer_store_only(c: &mut Criterion) {
+    let input = genomic(BGZF_BLOCK_SIZE * 100); // ~6.5 MB; content is irrelevant to the store path
+
+    let mut group = c.benchmark_group("writer_store_only");
+    group.throughput(Throughput::Bytes(input.len() as u64));
+    group.bench_function("write", |b| {
+        b.iter(|| {
+            // Store-only output is marginally larger than the input (framing overhead).
+            let mut output = Vec::with_capacity(input.len() + input.len() / 16);
+            let mut writer = Writer::new(&mut output, CompressionLevel::new(0).unwrap());
+            writer.write_all(black_box(&input)).unwrap();
+            writer.finish().unwrap();
+            black_box(output);
+        })
+    });
+    group.finish();
+}
+
+/// Read a store-only BGZF blob (level 0 => DEFLATE stored blocks). This is the path the
+/// stored-block read fast path targets: no real inflate, just a verbatim copy and CRC.
+fn bench_reader_store_only(c: &mut Criterion) {
+    let data = genomic(BGZF_BLOCK_SIZE * 100); // ~6.5 MB
+    let blob = make_bgzf(&data, 0);
+
+    let mut group = c.benchmark_group("reader_store_only");
+    group.throughput(Throughput::Bytes(data.len() as u64));
+    group.bench_function("read", |b| {
+        b.iter(|| {
+            let mut reader = Reader::new(blob.as_slice());
+            let mut out = Vec::with_capacity(data.len());
+            reader.read_to_end(&mut out).unwrap();
+            black_box(&out);
+        })
+    });
+    group.finish();
+}
+
+/// Read a store-only blob and re-emit it store-only via `io::copy` — the store-only
+/// transcode pipeline, exercising both fast paths end to end.
+fn bench_roundtrip_store_only(c: &mut Criterion) {
+    let data = genomic(BGZF_BLOCK_SIZE * 100); // ~6.5 MB
+    let blob = make_bgzf(&data, 0);
+
+    let mut group = c.benchmark_group("roundtrip_store_only");
+    group.throughput(Throughput::Bytes(data.len() as u64));
+    group.bench_function("copy", |b| {
+        b.iter(|| {
+            let mut reader = Reader::new(blob.as_slice());
+            let mut out = Vec::with_capacity(blob.len());
+            let mut writer = Writer::new(&mut out, CompressionLevel::new(0).unwrap());
+            io::copy(&mut reader, &mut writer).unwrap();
+            writer.finish().unwrap();
+            black_box(&out);
+        })
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_compressor_single_block,
     bench_compressor_levels,
     bench_writer_throughput,
-    bench_writer_file_io
+    bench_writer_file_io,
+    bench_reader,
+    bench_roundtrip,
+    bench_writer_store_only,
+    bench_reader_store_only,
+    bench_roundtrip_store_only
 );
 criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,8 +588,8 @@ mod test {
     }
 
     /// A block whose footer ISIZE claims more uncompressed bytes than the DEFLATE
-    /// payload actually produces must be rejected as corrupt — never read past the
-    /// region the decompressor initialized (which the reader now leaves uninitialized).
+    /// payload actually produces must be rejected as corrupt, rather than serving the
+    /// stale bytes left in the reader's reused decompression buffer from a prior block.
     #[test]
     fn block_claiming_more_bytes_than_payload_is_rejected() {
         let mut compressor = Compressor::new(CompressionLevel::new(3).unwrap());
@@ -747,6 +747,31 @@ mod test {
         let mut decoded = vec![];
         Reader::new(out.as_slice()).read_to_end(&mut decoded).unwrap();
         assert_eq!(decoded, input);
+    }
+
+    /// At level 0, interleaving writes with `flush()` calls must still yield exactly one EOF
+    /// marker and round-trip to the concatenated input — each flush merely forces an earlier
+    /// block boundary, and a flush with nothing buffered emits no block.
+    #[test]
+    fn store_only_multiple_flush_single_eof_and_round_trips() {
+        let mut output = vec![];
+        {
+            let mut writer = Writer::new(&mut output, CompressionLevel::new(0).unwrap());
+            writer.write_all(b"hello ").unwrap();
+            writer.flush().unwrap();
+            writer.write_all(b"store-only ").unwrap();
+            writer.flush().unwrap();
+            writer.flush().unwrap(); // second consecutive flush must not emit an empty block
+            writer.write_all(b"world").unwrap();
+            writer.finish().unwrap();
+        }
+
+        let eof_count = output.windows(BGZF_EOF.len()).filter(|w| *w == BGZF_EOF).count();
+        assert_eq!(eof_count, 1, "EOF marker should appear exactly once across flushes");
+
+        let mut decoded = vec![];
+        Reader::new(output.as_slice()).read_to_end(&mut decoded).unwrap();
+        assert_eq!(decoded, b"hello store-only world");
     }
 
     /// At level 0 the EOF marker must be written exactly once when relying on Drop.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,8 +270,11 @@ impl Compressor {
             .deflate_compress(input, &mut buffer[BGZF_HEADER_SIZE..])
             .map_err(BgzfError::LibDeflaterCompress)?;
 
-        if bytes_written >= MAX_BGZF_BLOCK_SIZE {
-            return Err(BgzfError::BlockSizeExceeded(bytes_written, MAX_BGZF_BLOCK_SIZE));
+        // The whole block (header + deflate output + footer) must fit in BSIZE+1, i.e. be at most
+        // MAX_BGZF_BLOCK_SIZE; otherwise BSIZE (a u16) would overflow in `header_inner`.
+        let block_size = BGZF_HEADER_SIZE + bytes_written + BGZF_FOOTER_SIZE;
+        if block_size > MAX_BGZF_BLOCK_SIZE {
+            return Err(BgzfError::BlockSizeExceeded(block_size, MAX_BGZF_BLOCK_SIZE));
         }
 
         // Write header
@@ -591,6 +594,33 @@ mod test {
         let mut out = vec![];
         let result = Reader::new(block.as_slice()).read_to_end(&mut out);
         assert!(result.is_err(), "block whose ISIZE exceeds its payload must error");
+    }
+
+    /// A compressed block whose framing would exceed the maximum BGZF block size must be rejected,
+    /// not silently produce a corrupt (overflowed) BSIZE. Incompressible input near the size limit
+    /// drives `bytes_written` into the range where a too-loose guard would let the u16 BSIZE wrap.
+    #[test]
+    fn compress_rejects_oversized_block_without_overflowing_bsize() {
+        fn incompressible(len: usize) -> Vec<u8> {
+            let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
+            let mut out = Vec::with_capacity(len + 8);
+            while out.len() < len {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                out.extend_from_slice(&state.to_le_bytes());
+            }
+            out.truncate(len);
+            out
+        }
+
+        let mut compressor = Compressor::new(CompressionLevel::new(12).unwrap());
+        let mut block = vec![];
+        let result = compressor.compress(&incompressible(65_515), &mut block);
+        assert!(
+            matches!(result, Err(BgzfError::BlockSizeExceeded(..))),
+            "expected BlockSizeExceeded, got {result:?}"
+        );
     }
 
     /// A compressed block whose footer ISIZE exceeds the maximum BGZF block size must be rejected

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,20 +330,29 @@ impl Decompressor {
         input: &[u8],
         output: &mut [u8],
         checksum_values: ChecksumValues,
+        validate_crc: bool,
     ) -> BgzfResult<()> {
-        // Only the bytes `deflate_decompress` actually writes belong to this block; a corrupt block
-        // can produce fewer than the footer's ISIZE, and `output` may still hold stale bytes from a
-        // previous, larger block. Checksum just the written prefix (and reject a short block) rather
-        // than the whole `output`.
         let decompressed = if checksum_values.amount != 0 {
             self.inner_mut().deflate_decompress(input, output)?
         } else {
             0
         };
 
-        let found = crc32(&output[..decompressed]);
-        if decompressed != output.len() || found != checksum_values.sum {
+        // The size check is cheap and guards against serving stale buffer bytes (a corrupt block
+        // can produce fewer than the footer's ISIZE), so it always runs regardless of CRC settings;
+        // it reports the real CRC of what was produced (this is the cold error path, so computing it
+        // is free). The full CRC pass below is the expensive part and is skipped when the caller has
+        // opted out of validation. When the size matches, `output` and `output[..decompressed]` are
+        // the same slice.
+        if decompressed != output.len() {
+            let found = crc32(&output[..decompressed]);
             return Err(BgzfError::InvalidChecksum { found, expected: checksum_values.sum });
+        }
+        if validate_crc {
+            let found = crc32(output);
+            if found != checksum_values.sum {
+                return Err(BgzfError::InvalidChecksum { found, expected: checksum_values.sum });
+            }
         }
         Ok(())
     }
@@ -638,17 +647,9 @@ mod test {
         block[len - 4..].copy_from_slice(&100_000u32.to_le_bytes());
 
         let mut out = vec![];
-        let err = Reader::new(block.as_slice())
-            .read_to_end(&mut out)
-            .expect_err("ISIZE beyond the max block size must error, not panic");
-        let bgzf = err
-            .get_ref()
-            .and_then(|e| e.downcast_ref::<BgzfError>())
-            .expect("reader errors wrap a BgzfError");
-        assert!(
-            matches!(bgzf, BgzfError::UncompressedSizeExceeded { .. }),
-            "expected UncompressedSizeExceeded, got {bgzf:?}"
-        );
+        assert_bgzf_err(Reader::new(block.as_slice()).read_to_end(&mut out), |e| {
+            matches!(e, BgzfError::UncompressedSizeExceeded { .. })
+        });
     }
 
     /// Compression level 0 must emit a single final DEFLATE stored block — the shape the
@@ -759,6 +760,132 @@ mod test {
         assert!(out.ends_with(BGZF_EOF), "output should end with the EOF marker");
         let eof_count = out.windows(BGZF_EOF.len()).filter(|w| *w == BGZF_EOF).count();
         assert_eq!(eof_count, 1, "EOF marker should appear exactly once");
+    }
+
+    /// Assert that a reader error wraps a [`BgzfError`] matching `want`.
+    fn assert_bgzf_err(result: std::io::Result<usize>, want: impl Fn(&BgzfError) -> bool) {
+        let err = result.expect_err("expected an error");
+        let bgzf = err
+            .get_ref()
+            .and_then(|e| e.downcast_ref::<BgzfError>())
+            .expect("reader errors wrap a BgzfError");
+        assert!(want(bgzf), "unexpected error variant: {bgzf:?}");
+    }
+
+    /// With CRC validation disabled, a stored block whose footer CRC32 is corrupt must still be
+    /// read (the caller has opted out of integrity for speed); the default reader must reject it
+    /// specifically as a checksum failure.
+    #[test]
+    fn reader_can_skip_crc_validation_on_stored_blocks() {
+        let input = b"uncompressed payload bytes";
+        let mut blob = vec![];
+        let mut writer = Writer::new(&mut blob, CompressionLevel::new(0).unwrap());
+        writer.write_all(input).unwrap();
+        writer.finish().unwrap();
+
+        // Corrupt the first (only) data block's footer CRC32. Layout: header + stored framing +
+        // data + footer, with CRC32 as the first footer word.
+        let crc_off = BGZF_HEADER_SIZE + DEFLATE_STORED_HEADER_SIZE + input.len();
+        blob[crc_off] ^= 0x01;
+
+        let mut out = vec![];
+        assert_bgzf_err(Reader::new(blob.as_slice()).read_to_end(&mut out), |e| {
+            matches!(e, BgzfError::InvalidChecksum { .. })
+        });
+
+        let mut out = vec![];
+        Reader::new(blob.as_slice())
+            .with_crc_validation(false)
+            .read_to_end(&mut out)
+            .expect("validation disabled must accept the block");
+        assert_eq!(out, input);
+    }
+
+    /// CRC validation can also be skipped on the libdeflate (compressed) path.
+    #[test]
+    fn reader_can_skip_crc_validation_on_compressed_blocks() {
+        let input = vec![b'A'; 5000]; // compresses, so this is a real deflate block (not stored)
+        let mut blob = vec![];
+        let mut writer = Writer::new(&mut blob, CompressionLevel::new(6).unwrap());
+        writer.write_all(&input).unwrap();
+        writer.finish().unwrap();
+
+        // The block's footer precedes the 28-byte EOF marker; CRC32 is its first word.
+        let crc_off = blob.len() - BGZF_EOF.len() - BGZF_FOOTER_SIZE;
+        blob[crc_off] ^= 0x01;
+
+        let mut out = vec![];
+        assert_bgzf_err(Reader::new(blob.as_slice()).read_to_end(&mut out), |e| {
+            matches!(e, BgzfError::InvalidChecksum { .. })
+        });
+
+        let mut out = vec![];
+        Reader::new(blob.as_slice())
+            .with_crc_validation(false)
+            .read_to_end(&mut out)
+            .expect("validation disabled must accept the block");
+        assert_eq!(out, input);
+    }
+
+    /// Disabling CRC validation must NOT disable the cheap structural checks: a stream truncated
+    /// mid-block is still an error.
+    #[test]
+    fn truncated_block_errors_even_with_crc_validation_disabled() {
+        let input = vec![0x42u8; 1000];
+        let mut blob = vec![];
+        let mut writer = Writer::new(&mut blob, CompressionLevel::new(0).unwrap());
+        writer.write_all(&input).unwrap();
+        writer.finish().unwrap();
+
+        // Cut partway through the (single) data block, after its header but before its payload ends.
+        let truncated = &blob[..BGZF_HEADER_SIZE + DEFLATE_STORED_HEADER_SIZE + 100];
+        let mut out = vec![];
+        assert!(
+            Reader::new(truncated).with_crc_validation(false).read_to_end(&mut out).is_err(),
+            "a truncated block must error even with CRC validation off"
+        );
+    }
+
+    /// Disabling CRC validation must NOT disable the stored-block size check: a footer ISIZE that
+    /// disagrees with the DEFLATE LEN is still rejected.
+    #[test]
+    fn stored_isize_mismatch_errors_even_with_crc_validation_disabled() {
+        let input = vec![0x42u8; 1000];
+        let mut blob = vec![];
+        let mut writer = Writer::new(&mut blob, CompressionLevel::new(0).unwrap());
+        writer.write_all(&input).unwrap();
+        writer.finish().unwrap();
+
+        // Bump the footer's ISIZE so it no longer equals the stored block's LEN. ISIZE is the
+        // second footer word: header + stored framing + data + CRC32.
+        let isize_off =
+            BGZF_HEADER_SIZE + DEFLATE_STORED_HEADER_SIZE + input.len() + BGZF_SIZEOF_CRC32;
+        blob[isize_off] = blob[isize_off].wrapping_add(1);
+
+        let mut out = vec![];
+        assert_bgzf_err(
+            Reader::new(blob.as_slice()).with_crc_validation(false).read_to_end(&mut out),
+            |e| matches!(e, BgzfError::InvalidHeader(_)),
+        );
+    }
+
+    /// The CRC-off flag must persist across the whole read loop: a multi-block store-only stream
+    /// must round-trip with validation disabled.
+    #[test]
+    fn reader_skips_crc_across_multiple_blocks() {
+        // > 64 KiB at level 0 spans several stored blocks.
+        let input: Vec<u8> = (0..200_000u32).map(|i| (i % 251) as u8).collect();
+        let mut blob = vec![];
+        let mut writer = Writer::new(&mut blob, CompressionLevel::new(0).unwrap());
+        writer.write_all(&input).unwrap();
+        writer.finish().unwrap();
+
+        let mut decoded = vec![];
+        Reader::new(blob.as_slice())
+            .with_crc_validation(false)
+            .read_to_end(&mut decoded)
+            .expect("multi-block stream must read with validation off");
+        assert_eq!(decoded, input);
     }
 
     /// The reader must round-trip multi-block store-only data, exercising the stored-block fast

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,8 +61,11 @@ pub const BGZF_BLOCK_SIZE: usize = 65280;
 /// 128 KB default buffer size, same as pigz.
 pub const BUFSIZE: usize = 128 * 1024;
 
-/// Default from bgzf: compress(BGZF_BLOCK_SIZE) < BGZF_MAX_BLOCK_SIZE
-/// 65536 which is u16::MAX + 1
+/// The maximum size, in bytes, of a complete BGZF block (header + payload + footer); the on-disk
+/// `BSIZE` field is this minus one, so it must fit in a `u16` (65536 = `u16::MAX` + 1). This is also
+/// the largest uncompressed size any single block can hold, so the reader sizes its decompression
+/// buffer to it and rejects blocks whose ISIZE claims more (see [`BgzfError::UncompressedSizeExceeded`]).
+/// Matches htslib's `BGZF_MAX_BLOCK_SIZE`.
 pub(crate) const MAX_BGZF_BLOCK_SIZE: usize = 64 * 1024;
 
 pub(crate) static BGZF_EOF: &[u8] = &[
@@ -83,6 +86,8 @@ pub(crate) static BGZF_EOF: &[u8] = &[
 
 pub(crate) const BGZF_HEADER_SIZE: usize = 18;
 pub(crate) const BGZF_FOOTER_SIZE: usize = 8;
+/// Size of a DEFLATE stored-block header: 1 byte (BFINAL/BTYPE) + LEN (u16 LE) + NLEN (u16 LE).
+pub(crate) const DEFLATE_STORED_HEADER_SIZE: usize = 5;
 pub(crate) const BGZF_SIZEOF_CRC32: usize = 4;
 pub(crate) const BGZF_NAME_COMMENT_EXTRA_FLAG: u8 = 4;
 pub(crate) const BGZF_SUBFIELD_ID1: u8 = b'B';
@@ -123,6 +128,8 @@ pub enum BgzfError {
     InvalidChecksum { found: u32, expected: u32 },
     #[error("Invalid block header: {0}")]
     InvalidHeader(&'static str),
+    #[error("Uncompressed block size ({found}) exceeds maximum ({max})")]
+    UncompressedSizeExceeded { found: usize, max: usize },
     #[error("LibDeflater compression error: {0:?}")]
     LibDeflaterCompress(libdeflater::CompressionError),
     #[error(transparent)]
@@ -140,7 +147,9 @@ struct ChecksumValues {
 
 /// Level of compression to use for for the compressors.
 ///
-/// Valid values are 1-12. See [libdeflater](https://github.com/ebiggers/libdeflate#compression-levels) documentation on levels.
+/// Valid values are 0-12, where 0 stores the data uncompressed (DEFLATE stored blocks) and is the
+/// fastest to both write and read. Levels 1-12 invoke libdeflate; see its
+/// [documentation](https://github.com/ebiggers/libdeflate#compression-levels) on levels.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CompressionLevel(CompressionLvl);
 
@@ -148,7 +157,7 @@ pub struct CompressionLevel(CompressionLvl);
 impl CompressionLevel {
     /// Create a new [`CompressionLevel`] instance.
     ///
-    /// Valid levels are 1-12.
+    /// Valid levels are 0-12; level 0 stores the data uncompressed.
     #[allow(clippy::cast_lossless)]
     pub fn new(level: u8) -> BgzfResult<Self> {
         // libdeflater::CompressionLvlError contains no information
@@ -265,10 +274,6 @@ impl Compressor {
             return Err(BgzfError::BlockSizeExceeded(bytes_written, MAX_BGZF_BLOCK_SIZE));
         }
 
-        // Compute CRC32
-        let mut crc = libdeflater::Crc::new();
-        crc.update(input);
-
         // Write header
         let header = header_inner(self.level, bytes_written as u16);
         buffer[0..BGZF_HEADER_SIZE].copy_from_slice(&header);
@@ -276,7 +281,7 @@ impl Compressor {
         // Write footer directly at computed offset
         let footer_offset = BGZF_HEADER_SIZE + bytes_written;
         buffer[footer_offset..footer_offset + BGZF_SIZEOF_CRC32]
-            .copy_from_slice(&crc.sum().to_le_bytes());
+            .copy_from_slice(&crc32(input).to_le_bytes());
         buffer[footer_offset + BGZF_SIZEOF_CRC32..footer_offset + BGZF_FOOTER_SIZE]
             .copy_from_slice(&(input.len() as u32).to_le_bytes());
 
@@ -323,17 +328,19 @@ impl Decompressor {
         output: &mut [u8],
         checksum_values: ChecksumValues,
     ) -> BgzfResult<()> {
-        if checksum_values.amount != 0 {
-            let _bytes_decompressed = self.inner_mut().deflate_decompress(input, output)?;
-        }
-        let mut new_check = libdeflater::Crc::new();
-        new_check.update(output);
+        // Only the bytes `deflate_decompress` actually writes belong to this block; a corrupt block
+        // can produce fewer than the footer's ISIZE, and `output` may still hold stale bytes from a
+        // previous, larger block. Checksum just the written prefix (and reject a short block) rather
+        // than the whole `output`.
+        let decompressed = if checksum_values.amount != 0 {
+            self.inner_mut().deflate_decompress(input, output)?
+        } else {
+            0
+        };
 
-        if checksum_values.sum != new_check.sum() {
-            return Err(BgzfError::InvalidChecksum {
-                found: new_check.sum(),
-                expected: checksum_values.sum,
-            });
+        let found = crc32(&output[..decompressed]);
+        if decompressed != output.len() || found != checksum_values.sum {
+            return Err(BgzfError::InvalidChecksum { found, expected: checksum_values.sum });
         }
         Ok(())
     }
@@ -402,6 +409,36 @@ fn get_footer_values(input: &[u8]) -> ChecksumValues {
 #[inline]
 fn strip_footer(input: &[u8]) -> &[u8] {
     &input[..input.len() - BGZF_FOOTER_SIZE]
+}
+
+/// Compute the gzip/BGZF CRC32 of `data`.
+#[inline]
+fn crc32(data: &[u8]) -> u32 {
+    let mut crc = libdeflater::Crc::new();
+    crc.update(data);
+    crc.sum()
+}
+
+/// If `deflate_header` (the start of a DEFLATE stream) begins a single, final *stored*
+/// (uncompressed) block, return its declared length (`LEN`); otherwise return `None`.
+///
+/// BGZF written at compression level 0 — and the "no compression" mode of other tools — encodes
+/// each block this way. The caller still confirms that `LEN` matches the block's framing, CRC and
+/// uncompressed size before trusting it; any other shape (real compressed data, the empty EOF
+/// block, a non-final or multi-block stream, or a corrupt length field) returns `None` and is left
+/// to the normal decompression path.
+#[inline]
+fn stored_block_len(deflate_header: &[u8]) -> Option<usize> {
+    // The header is a 1-byte field (BFINAL in bit 0, BTYPE in bits 1-2) followed by LEN and NLEN
+    // (u16 little-endian, NLEN = !LEN). A final stored block has BFINAL=1, BTYPE=00, i.e. low three
+    // bits 0b001.
+    if deflate_header.len() < DEFLATE_STORED_HEADER_SIZE || deflate_header[0] & 0b0000_0111 != 0b001
+    {
+        return None;
+    }
+    let len = u16::from_le_bytes([deflate_header[1], deflate_header[2]]);
+    let nlen = u16::from_le_bytes([deflate_header[3], deflate_header[4]]);
+    (nlen == !len).then_some(len as usize)
 }
 
 #[cfg(test)]
@@ -538,6 +575,177 @@ mod test {
         assert_eq!(input.to_vec(), bytes);
     }
 
+    /// A block whose footer ISIZE claims more uncompressed bytes than the DEFLATE
+    /// payload actually produces must be rejected as corrupt — never read past the
+    /// region the decompressor initialized (which the reader now leaves uninitialized).
+    #[test]
+    fn block_claiming_more_bytes_than_payload_is_rejected() {
+        let mut compressor = Compressor::new(CompressionLevel::new(3).unwrap());
+        let mut block = vec![];
+        compressor.compress(b"hello world", &mut block).unwrap();
+
+        // Inflate the footer's ISIZE (last four bytes, little-endian) past the real size.
+        let len = block.len();
+        block[len - 4..].copy_from_slice(&200u32.to_le_bytes());
+
+        let mut out = vec![];
+        let result = Reader::new(block.as_slice()).read_to_end(&mut out);
+        assert!(result.is_err(), "block whose ISIZE exceeds its payload must error");
+    }
+
+    /// A compressed block whose footer ISIZE exceeds the maximum BGZF block size must be rejected
+    /// with [`BgzfError::UncompressedSizeExceeded`] rather than panicking against the fixed-size
+    /// decompression buffer. A compressed (non-stored) block is used so the reader takes the
+    /// libdeflate path where that guard lives.
+    #[test]
+    fn block_with_oversized_isize_is_rejected() {
+        let mut compressor = Compressor::new(CompressionLevel::new(6).unwrap());
+        let mut block = vec![];
+        compressor.compress(&[b'A'; 1024], &mut block).unwrap(); // compresses, so not a stored block
+
+        // Claim far more uncompressed bytes than the buffer can hold (last four bytes = ISIZE).
+        let len = block.len();
+        block[len - 4..].copy_from_slice(&100_000u32.to_le_bytes());
+
+        let mut out = vec![];
+        let err = Reader::new(block.as_slice())
+            .read_to_end(&mut out)
+            .expect_err("ISIZE beyond the max block size must error, not panic");
+        let bgzf = err
+            .get_ref()
+            .and_then(|e| e.downcast_ref::<BgzfError>())
+            .expect("reader errors wrap a BgzfError");
+        assert!(
+            matches!(bgzf, BgzfError::UncompressedSizeExceeded { .. }),
+            "expected UncompressedSizeExceeded, got {bgzf:?}"
+        );
+    }
+
+    /// Compression level 0 must emit a single final DEFLATE stored block — the shape the
+    /// reader's fast path detects and copies without invoking libdeflate.
+    #[test]
+    fn level_0_emits_a_single_final_stored_block() {
+        let mut compressor = Compressor::new(CompressionLevel::new(0).unwrap());
+        let input = b"the quick brown fox jumps over the lazy dog";
+        let mut block = vec![];
+        compressor.compress(input, &mut block).unwrap();
+
+        let deflate = &block[BGZF_HEADER_SIZE..block.len() - BGZF_FOOTER_SIZE];
+        let len = stored_block_len(deflate).expect("level 0 should produce a stored block");
+        assert_eq!(len, input.len());
+        assert_eq!(&deflate[DEFLATE_STORED_HEADER_SIZE..], input);
+    }
+
+    /// Real compressed data (level 6) is not a stored block, so the fast path must decline it
+    /// and leave decompression to libdeflate.
+    #[test]
+    fn compressed_block_is_not_detected_as_stored() {
+        let mut compressor = Compressor::new(CompressionLevel::new(6).unwrap());
+        let input = vec![b'A'; 4096]; // highly compressible => real deflate, not a stored block
+        let mut block = vec![];
+        compressor.compress(&input, &mut block).unwrap();
+
+        let deflate = &block[BGZF_HEADER_SIZE..block.len() - BGZF_FOOTER_SIZE];
+        assert!(stored_block_len(deflate).is_none());
+    }
+
+    /// The store-only writer must frame output as DEFLATE stored blocks, produce the same bytes
+    /// regardless of how writes are chunked across block boundaries, and round-trip.
+    #[test]
+    fn store_only_writer_emits_stored_blocks_across_chunked_writes() {
+        let input: Vec<u8> = (0..150_000u32).map(|i| i.wrapping_mul(2_654_435_761) as u8).collect();
+
+        let one_shot = {
+            let mut out = vec![];
+            let mut writer = Writer::new(&mut out, CompressionLevel::new(0).unwrap());
+            writer.write_all(&input).unwrap();
+            writer.finish().unwrap();
+            out
+        };
+        let chunked = {
+            let mut out = vec![];
+            let mut writer = Writer::new(&mut out, CompressionLevel::new(0).unwrap());
+            for chunk in input.chunks(7) {
+                writer.write_all(chunk).unwrap();
+            }
+            writer.finish().unwrap();
+            out
+        };
+
+        // Block boundaries depend only on the block size, so the framed output must be identical.
+        assert_eq!(one_shot, chunked, "chunked writes must produce identical framing");
+
+        // The first block must be a DEFLATE stored block...
+        let first_deflate =
+            &one_shot[BGZF_HEADER_SIZE..BGZF_HEADER_SIZE + DEFLATE_STORED_HEADER_SIZE];
+        assert!(stored_block_len(first_deflate).is_some(), "level 0 must emit stored blocks");
+
+        // ...and the whole thing must round-trip.
+        let mut decoded = vec![];
+        Reader::new(one_shot.as_slice()).read_to_end(&mut decoded).unwrap();
+        assert_eq!(decoded, input);
+    }
+
+    /// At level 0, writing no data must still produce exactly the EOF marker — never a spurious
+    /// empty stored block (guarded by `store_data_len > 0` in the writer's flush).
+    #[test]
+    fn store_only_empty_input_writes_only_eof() {
+        let mut out = vec![];
+        Writer::new(&mut out, CompressionLevel::new(0).unwrap()).finish().unwrap();
+        assert_eq!(out.as_slice(), BGZF_EOF);
+    }
+
+    /// Input that is an exact multiple of the block size must emit full blocks with no trailing
+    /// empty block, and still round-trip.
+    #[test]
+    fn store_only_exact_block_multiple_has_no_trailing_empty_block() {
+        let blocksize = 1024;
+        let input = vec![0x5Au8; blocksize * 3];
+
+        let mut out = vec![];
+        let mut writer =
+            Writer::with_capacity(&mut out, CompressionLevel::new(0).unwrap(), blocksize);
+        writer.write_all(&input).unwrap();
+        writer.finish().unwrap();
+
+        // Exactly three full stored blocks followed by the EOF marker — nothing else.
+        let block_bytes =
+            BGZF_HEADER_SIZE + DEFLATE_STORED_HEADER_SIZE + blocksize + BGZF_FOOTER_SIZE;
+        assert_eq!(out.len(), block_bytes * 3 + BGZF_EOF.len());
+
+        let mut decoded = vec![];
+        Reader::new(out.as_slice()).read_to_end(&mut decoded).unwrap();
+        assert_eq!(decoded, input);
+    }
+
+    /// At level 0 the EOF marker must be written exactly once when relying on Drop.
+    #[test]
+    fn store_only_eof_written_once_on_drop() {
+        let mut out = vec![];
+        {
+            let mut writer = Writer::new(&mut out, CompressionLevel::new(0).unwrap());
+            writer.write_all(b"some store-only data").unwrap();
+        }
+        assert!(out.ends_with(BGZF_EOF), "output should end with the EOF marker");
+        let eof_count = out.windows(BGZF_EOF.len()).filter(|w| *w == BGZF_EOF).count();
+        assert_eq!(eof_count, 1, "EOF marker should appear exactly once");
+    }
+
+    /// The reader must round-trip multi-block store-only data, exercising the stored-block fast
+    /// path across several blocks.
+    #[test]
+    fn reader_round_trips_store_only_data() {
+        let input: Vec<u8> = (0..200_000u32).map(|i| (i % 251) as u8).collect();
+        let mut blob = vec![];
+        let mut writer = Writer::new(&mut blob, CompressionLevel::new(0).unwrap());
+        writer.write_all(&input).unwrap();
+        writer.finish().unwrap();
+
+        let mut decoded = vec![];
+        Reader::new(blob.as_slice()).read_to_end(&mut decoded).unwrap();
+        assert_eq!(decoded, input);
+    }
+
     const DICT_SIZE: usize = 32768;
     proptest! {
         #[test]
@@ -545,7 +753,7 @@ mod test {
             input in prop::collection::vec(0..u8::MAX, 1..(DICT_SIZE * 10)),
             buf_size in DICT_SIZE..BGZF_BLOCK_SIZE,
             write_size in 1..BGZF_BLOCK_SIZE * 4,
-            comp_level in 1..12_u8
+            comp_level in 0..=12_u8
         ) {
             let dir = tempdir().unwrap();
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -13,6 +13,9 @@ use crate::{
 
 /// A BGZF reader.
 ///
+/// Each block's CRC32 is validated by default. For a faster read of trusted, transient
+/// uncompressed data you can turn that off — see [`Reader::with_crc_validation`].
+///
 /// # Example
 ///
 /// ```rust
@@ -50,6 +53,8 @@ where
     /// Holds the 18-byte BGZF header plus the following 5-byte DEFLATE block header, read together
     /// so the stored fast path can be chosen without a second read.
     header_buffer: Vec<u8>,
+    /// Whether to recompute and check each block's CRC32 (default: `true`).
+    validate_crc: bool,
     decompressor: Decompressor,
     reader: R,
 }
@@ -66,9 +71,38 @@ where
             block_pos: 0,
             block_end: 0,
             header_buffer: vec![0u8; BGZF_HEADER_SIZE + DEFLATE_STORED_HEADER_SIZE],
+            validate_crc: true,
             decompressor: Decompressor::new(),
             reader,
         }
+    }
+
+    /// Enable or disable CRC32 validation of each block's uncompressed data (default: enabled).
+    ///
+    /// BGZF stores a CRC32 of every block's uncompressed bytes; by default the reader recomputes
+    /// and checks it, rejecting corrupt blocks. Disabling validation skips that pass — a sizable
+    /// speedup for store-only (uncompressed) data, where decoding is otherwise CRC-bound — but the
+    /// block's *uncompressed content* is then not verified at all: it is copied verbatim on the
+    /// stored path, and only its length and decodability are checked on the compressed path. The
+    /// cheap structural checks — block framing and uncompressed-size (ISIZE) agreement — still run,
+    /// so a malformed block is still rejected; only content corruption that preserves the block's
+    /// length goes undetected.
+    ///
+    /// This reads more leniently than the format intends (samtools/htslib always verify), so disable
+    /// it only for trusted, transient streams whose integrity is already assured — e.g. uncompressed
+    /// BAM piped between processes — never for data read from disk or an untrusted source.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bgzf::Reader;
+    /// # let compressed: &[u8] = &[];
+    /// let reader = Reader::new(compressed).with_crc_validation(false);
+    /// ```
+    #[must_use]
+    pub fn with_crc_validation(mut self, validate: bool) -> Self {
+        self.validate_crc = validate;
+        self
     }
 }
 
@@ -160,12 +194,14 @@ where
                             BgzfError::InvalidHeader("stored block length disagrees with footer"),
                         ));
                     }
-                    let found = crc32(&self.decompressed_buffer[..len]);
-                    if found != check.sum {
-                        return Err(io::Error::new(
-                            io::ErrorKind::Other,
-                            BgzfError::InvalidChecksum { found, expected: check.sum },
-                        ));
+                    if self.validate_crc {
+                        let found = crc32(&self.decompressed_buffer[..len]);
+                        if found != check.sum {
+                            return Err(io::Error::new(
+                                io::ErrorKind::Other,
+                                BgzfError::InvalidChecksum { found, expected: check.sum },
+                            ));
+                        }
                     }
                     self.block_pos = 0;
                     self.block_end = len;
@@ -200,6 +236,7 @@ where
                     strip_footer(compressed),
                     &mut self.decompressed_buffer[..decompressed_len],
                     check,
+                    self.validate_crc,
                 )
                 .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
             self.block_pos = 0;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -5,11 +5,10 @@ use std::{
     path::Path,
 };
 
-use bytes::{Buf, BytesMut};
-
 use crate::{
-    check_header, get_block_size, get_footer_values, strip_footer, Decompressor, BGZF_BLOCK_SIZE,
-    BGZF_HEADER_SIZE, BUFSIZE,
+    check_header, crc32, get_block_size, get_footer_values, stored_block_len, strip_footer,
+    BgzfError, Decompressor, BGZF_FOOTER_SIZE, BGZF_HEADER_SIZE, DEFLATE_STORED_HEADER_SIZE,
+    MAX_BGZF_BLOCK_SIZE,
 };
 
 /// A BGZF reader.
@@ -39,8 +38,17 @@ pub struct Reader<R>
 where
     R: Read,
 {
-    decompressed_buffer: BytesMut,
-    compressed_buffer: BytesMut,
+    /// Holds the current block's uncompressed bytes; callers are served out of this buffer. Stored
+    /// blocks are read straight into it, inflated blocks are written into it by the decompressor.
+    decompressed_buffer: Vec<u8>,
+    /// Scratch buffer used only on the inflate path to assemble a block's raw DEFLATE payload.
+    compressed_buffer: Vec<u8>,
+    /// Start of the current block's unread uncompressed bytes within `decompressed_buffer`.
+    block_pos: usize,
+    /// End (exclusive) of the current block's uncompressed bytes within `decompressed_buffer`.
+    block_end: usize,
+    /// Holds the 18-byte BGZF header plus the following 5-byte DEFLATE block header, read together
+    /// so the stored fast path can be chosen without a second read.
     header_buffer: Vec<u8>,
     decompressor: Decompressor,
     reader: R,
@@ -51,13 +59,14 @@ where
     R: Read,
 {
     pub fn new(reader: R) -> Self {
-        let decompressor = Decompressor::new();
-
         Self {
-            decompressed_buffer: BytesMut::with_capacity(BUFSIZE),
-            compressed_buffer: BytesMut::with_capacity(BGZF_BLOCK_SIZE),
-            header_buffer: vec![0; BGZF_HEADER_SIZE],
-            decompressor,
+            // Pre-allocate to the maximum block sizes so no per-block resize is ever needed.
+            decompressed_buffer: vec![0u8; MAX_BGZF_BLOCK_SIZE],
+            compressed_buffer: vec![0u8; MAX_BGZF_BLOCK_SIZE],
+            block_pos: 0,
+            block_end: 0,
+            header_buffer: vec![0u8; BGZF_HEADER_SIZE + DEFLATE_STORED_HEADER_SIZE],
+            decompressor: Decompressor::new(),
             reader,
         }
     }
@@ -82,64 +91,142 @@ where
     ///
     /// - `Ok(0)` means that EOF has been reached or `buf.len() == 0`.
     /// - `Ok(n < buf.len()` means that EOF has been reached.
-    /// - `Err(..)` means that an error has ocurred
+    /// - `Err(..)` means that an error has occurred.
+    ///
+    /// A stream that ends cleanly on a block boundary is treated as end-of-input (a missing EOF
+    /// marker is tolerated). A stream that ends partway through a block — a truncated block — is
+    /// reported as an error rather than silently ignored.
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut total_bytes_copied = 0;
         loop {
-            let available_bytes = self.decompressed_buffer.remaining();
-            let remaining_bytes_needed = buf.len() - total_bytes_copied;
-            // There are bytes we've already decompressed but haven't copied to the output buffer yet
-            if available_bytes > remaining_bytes_needed {
-                // The total decompressed is greater than the output buffer
-                self.decompressed_buffer.copy_to_slice(&mut buf[total_bytes_copied..]);
-            } else if !self.decompressed_buffer.is_empty() {
-                // The total decompressed is less than the output buffer
-                self.decompressed_buffer.copy_to_slice(
-                    &mut buf[total_bytes_copied..total_bytes_copied + available_bytes],
-                );
+            // Drain the current block before fetching the next one.
+            let available = self.block_end - self.block_pos;
+            if available > 0 {
+                let n = available.min(buf.len() - total_bytes_copied);
+                buf[total_bytes_copied..total_bytes_copied + n]
+                    .copy_from_slice(&self.decompressed_buffer[self.block_pos..self.block_pos + n]);
+                self.block_pos += n;
+                total_bytes_copied += n;
             }
-            total_bytes_copied += available_bytes - self.decompressed_buffer.remaining();
 
-            // Check if we've filled the output buffer. If it hasn't been filled then decompress another block.
             if total_bytes_copied == buf.len() {
-                // The output buffer has been filled, return
                 break;
             }
 
-            debug_assert!(
-                total_bytes_copied < buf.len(),
-                "Check that we haven't somehow ended up with more bytes than should be possible."
-            );
+            debug_assert!(total_bytes_copied < buf.len(), "More bytes copied than requested.");
 
-            // The output buffer hasn't been filled, try to decompress another block. If another
-            // block is not available then we are done.
-            self.header_buffer.fill(0);
-            if let Ok(()) = self.reader.read_exact(&mut self.header_buffer) {
-                check_header(&self.header_buffer)
-                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-                let size = get_block_size(&self.header_buffer);
-
-                self.compressed_buffer.clear();
-                self.compressed_buffer.resize(size - BGZF_HEADER_SIZE, 0);
-                self.reader.read_exact(&mut self.compressed_buffer)?;
-
-                let check = get_footer_values(&self.compressed_buffer);
-                self.decompressed_buffer.clear();
-                self.decompressed_buffer.resize(check.amount as usize, 0);
-
-                self.decompressor
-                    .decompress(
-                        strip_footer(&self.compressed_buffer),
-                        &mut self.decompressed_buffer,
-                        check,
-                    )
-                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-            } else {
-                break;
+            // Read the 18-byte BGZF header together with the 5-byte DEFLATE block header. Reading
+            // both at once lets us choose the stored fast path without a second read: a clean EOF
+            // at a block boundary stops the stream, while a partial read signals a truncated block.
+            if !read_full(&mut self.reader, &mut self.header_buffer)? {
+                break; // clean EOF
             }
+            check_header(&self.header_buffer[..BGZF_HEADER_SIZE])
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+            // A valid block always holds at least a header and footer; anything smaller is a
+            // corrupt header and would underflow `payload_len`.
+            let block_size = get_block_size(&self.header_buffer[..BGZF_HEADER_SIZE]);
+            if block_size < BGZF_HEADER_SIZE + BGZF_FOOTER_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    BgzfError::InvalidHeader("block size smaller than header plus footer"),
+                ));
+            }
+            let payload_len = block_size - BGZF_HEADER_SIZE;
+
+            // The 5 bytes after the BGZF header are the DEFLATE block header. Copy them out so we
+            // can both inspect them and, on the inflate path, prepend them to the payload.
+            let deflate_header: [u8; DEFLATE_STORED_HEADER_SIZE] = self.header_buffer
+                [BGZF_HEADER_SIZE..]
+                .try_into()
+                .expect("header_buffer holds the DEFLATE block header");
+
+            // Fast path: a single final stored block that spans the whole payload holds its bytes
+            // verbatim. Read the data and its footer straight into the decompressed buffer (at
+            // offset 0, so callers drain an aligned, contiguous slice), skipping libdeflate and any
+            // staging copy, then verify the uncompressed size and CRC.
+            if let Some(len) = stored_block_len(&deflate_header) {
+                let with_footer = len + BGZF_FOOTER_SIZE;
+                if payload_len == DEFLATE_STORED_HEADER_SIZE + with_footer
+                    && with_footer <= self.decompressed_buffer.len()
+                {
+                    self.reader.read_exact(&mut self.decompressed_buffer[..with_footer])?;
+                    let check = get_footer_values(&self.decompressed_buffer[..with_footer]);
+                    if check.amount as usize != len {
+                        return Err(io::Error::new(
+                            io::ErrorKind::Other,
+                            BgzfError::InvalidHeader("stored block length disagrees with footer"),
+                        ));
+                    }
+                    let found = crc32(&self.decompressed_buffer[..len]);
+                    if found != check.sum {
+                        return Err(io::Error::new(
+                            io::ErrorKind::Other,
+                            BgzfError::InvalidChecksum { found, expected: check.sum },
+                        ));
+                    }
+                    self.block_pos = 0;
+                    self.block_end = len;
+                    continue;
+                }
+            }
+
+            // Inflate path: reassemble the payload (the 5 header bytes already read plus the
+            // remainder) into `compressed_buffer` and decompress it with libdeflate.
+            self.compressed_buffer[..DEFLATE_STORED_HEADER_SIZE].copy_from_slice(&deflate_header);
+            self.reader
+                .read_exact(&mut self.compressed_buffer[DEFLATE_STORED_HEADER_SIZE..payload_len])?;
+
+            let compressed = &self.compressed_buffer[..payload_len];
+            let check = get_footer_values(compressed);
+            let decompressed_len = check.amount as usize;
+
+            // The decompressed buffer is sized to the BGZF maximum; a block claiming more is
+            // corrupt and would otherwise index out of bounds.
+            if decompressed_len > self.decompressed_buffer.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    BgzfError::UncompressedSizeExceeded {
+                        found: decompressed_len,
+                        max: self.decompressed_buffer.len(),
+                    },
+                ));
+            }
+
+            self.decompressor
+                .decompress(
+                    strip_footer(compressed),
+                    &mut self.decompressed_buffer[..decompressed_len],
+                    check,
+                )
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            self.block_pos = 0;
+            self.block_end = decompressed_len;
         }
 
         Ok(total_bytes_copied)
     }
+}
+
+/// Fill `buf` completely from `reader`.
+///
+/// Returns `Ok(true)` once `buf` is full, `Ok(false)` if the stream ends cleanly before any byte is
+/// read (a normal end-of-stream at a block boundary), and an error if the stream ends partway
+/// through (a truncated block) or the underlying read fails.
+fn read_full<R: Read>(reader: &mut R, buf: &mut [u8]) -> io::Result<bool> {
+    let mut filled = 0;
+    while filled < buf.len() {
+        match reader.read(&mut buf[filled..]) {
+            Ok(0) if filled == 0 => return Ok(false),
+            Ok(0) => {
+                return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "truncated BGZF block"))
+            }
+            Ok(n) => filled += n,
+            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(true)
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -73,7 +73,11 @@ where
     ///
     /// By default the capacity is [`bgzf::BUFSIZE`]. The capacity must be less than or equal to [`bgzf::BGZF_BLOCK_SIZE`].
     pub fn with_capacity(writer: W, compression_level: CompressionLevel, blocksize: usize) -> Self {
-        assert!(blocksize <= BGZF_BLOCK_SIZE);
+        // A zero block size would loop forever while emitting blocks.
+        assert!(
+            (1..=BGZF_BLOCK_SIZE).contains(&blocksize),
+            "blocksize must be in 1..={BGZF_BLOCK_SIZE}"
+        );
         let compressor = Compressor::new(compression_level);
         // Level 0 stores data uncompressed; assemble each framed block directly in this buffer.
         let store_only = u8::from(compression_level) == 0;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -6,9 +6,11 @@ use std::{
 };
 
 use bytes::BytesMut;
+use libdeflater::Crc;
 
 use crate::{
-    CompressionLevel, Compressor, BGZF_BLOCK_SIZE, BGZF_EOF, BUFSIZE, MAX_BGZF_BLOCK_SIZE,
+    header_inner, CompressionLevel, Compressor, BGZF_BLOCK_SIZE, BGZF_EOF, BGZF_FOOTER_SIZE,
+    BGZF_HEADER_SIZE, BGZF_SIZEOF_CRC32, BUFSIZE, DEFLATE_STORED_HEADER_SIZE, MAX_BGZF_BLOCK_SIZE,
 };
 
 /// A BGZF writer.
@@ -36,14 +38,24 @@ pub struct Writer<W>
 where
     W: Write,
 {
-    /// The internal buffer to use
+    /// Buffer of not-yet-compressed bytes (compress path only).
     uncompressed_buffer: BytesMut,
-    /// The buffer to reuse for compressed bytes
+    /// Reusable output buffer. On the compress path it holds one compressed block; on the
+    /// store-only path it holds a fully framed DEFLATE stored block assembled in place.
     compressed_buffer: Vec<u8>,
     /// The size of the blocks to create
     blocksize: usize,
-    /// The compressor to reuse
+    /// The compression level, also recorded in each block header.
+    level: CompressionLevel,
+    /// The compressor to reuse (unused on the store-only path).
     compressor: Compressor,
+    /// True at compression level 0: blocks are emitted as DEFLATE stored blocks without invoking
+    /// libdeflate, accumulating straight into `compressed_buffer`.
+    store_only: bool,
+    /// Running CRC32 over the bytes accumulated in the current store-only block.
+    store_crc: Crc,
+    /// Number of data bytes accumulated in the current store-only block.
+    store_data_len: usize,
     /// The inner writer, wrapped in Option to allow taking ownership in finish()
     writer: Option<W>,
 }
@@ -63,11 +75,22 @@ where
     pub fn with_capacity(writer: W, compression_level: CompressionLevel, blocksize: usize) -> Self {
         assert!(blocksize <= BGZF_BLOCK_SIZE);
         let compressor = Compressor::new(compression_level);
+        // Level 0 stores data uncompressed; assemble each framed block directly in this buffer.
+        let store_only = u8::from(compression_level) == 0;
+        let compressed_buffer = if store_only {
+            vec![0u8; BGZF_HEADER_SIZE + DEFLATE_STORED_HEADER_SIZE + blocksize + BGZF_FOOTER_SIZE]
+        } else {
+            Vec::with_capacity(BUFSIZE)
+        };
         Self {
             uncompressed_buffer: BytesMut::with_capacity(BUFSIZE),
-            compressed_buffer: Vec::with_capacity(BUFSIZE),
+            compressed_buffer,
             blocksize,
+            level: compression_level,
             compressor,
+            store_only,
+            store_crc: Crc::new(),
+            store_data_len: 0,
             writer: Some(writer),
         }
     }
@@ -89,6 +112,13 @@ where
 
     /// Internal method to flush the uncompressed buffer without writing EOF.
     fn flush_buffer(&mut self) -> io::Result<()> {
+        if self.store_only {
+            // Emit whatever partial block has accumulated; an empty block is never written.
+            if self.store_data_len > 0 {
+                self.emit_store_block()?;
+            }
+            return Ok(());
+        }
         let writer = self
             .writer
             .as_mut()
@@ -104,6 +134,61 @@ where
             writer.write_all(&self.compressed_buffer)?;
             self.compressed_buffer.clear();
         }
+        Ok(())
+    }
+
+    /// Accumulate `buf` into the current store-only block, emitting full blocks as they fill.
+    fn write_store_only(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let data_offset = BGZF_HEADER_SIZE + DEFLATE_STORED_HEADER_SIZE;
+        let mut remaining = buf;
+        while !remaining.is_empty() {
+            let n = (self.blocksize - self.store_data_len).min(remaining.len());
+            let start = data_offset + self.store_data_len;
+            self.compressed_buffer[start..start + n].copy_from_slice(&remaining[..n]);
+            self.store_crc.update(&remaining[..n]);
+            self.store_data_len += n;
+            remaining = &remaining[n..];
+            if self.store_data_len == self.blocksize {
+                self.emit_store_block()?;
+            }
+        }
+        Ok(buf.len())
+    }
+
+    /// Frame the data accumulated in `compressed_buffer` as a single DEFLATE stored block, write
+    /// it to the inner writer, and reset for the next block.
+    fn emit_store_block(&mut self) -> io::Result<()> {
+        let data_len = self.store_data_len;
+        let data_offset = BGZF_HEADER_SIZE + DEFLATE_STORED_HEADER_SIZE;
+
+        // BGZF header. A stored block's "compressed" size is its 5-byte DEFLATE header plus data.
+        let header = header_inner(self.level, (DEFLATE_STORED_HEADER_SIZE + data_len) as u16);
+        self.compressed_buffer[..BGZF_HEADER_SIZE].copy_from_slice(&header);
+
+        // DEFLATE stored-block header: BFINAL=1, BTYPE=00, then LEN and its complement NLEN.
+        let len = data_len as u16;
+        self.compressed_buffer[BGZF_HEADER_SIZE] = 0b001;
+        self.compressed_buffer[BGZF_HEADER_SIZE + 1..BGZF_HEADER_SIZE + 3]
+            .copy_from_slice(&len.to_le_bytes());
+        self.compressed_buffer[BGZF_HEADER_SIZE + 3..BGZF_HEADER_SIZE + 5]
+            .copy_from_slice(&(!len).to_le_bytes());
+
+        // BGZF footer: CRC32 of the data followed by the uncompressed size.
+        let footer_offset = data_offset + data_len;
+        self.compressed_buffer[footer_offset..footer_offset + BGZF_SIZEOF_CRC32]
+            .copy_from_slice(&self.store_crc.sum().to_le_bytes());
+        self.compressed_buffer[footer_offset + BGZF_SIZEOF_CRC32..footer_offset + BGZF_FOOTER_SIZE]
+            .copy_from_slice(&(data_len as u32).to_le_bytes());
+
+        let end = footer_offset + BGZF_FOOTER_SIZE;
+        let writer = self
+            .writer
+            .as_mut()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "writer already finished"))?;
+        writer.write_all(&self.compressed_buffer[..end])?;
+
+        self.store_crc = Crc::new();
+        self.store_data_len = 0;
         Ok(())
     }
 }
@@ -138,6 +223,12 @@ where
 {
     /// Write a buffer into this writer, returning how many bytes were written.
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if self.store_only {
+            if self.writer.is_none() {
+                return Err(io::Error::new(io::ErrorKind::Other, "writer already finished"));
+            }
+            return self.write_store_only(buf);
+        }
         let writer = self
             .writer
             .as_mut()


### PR DESCRIPTION
## Summary

Adds fast paths for **store-only (compression level 0)** BGZF, plus a few
correctness fixes and a CRC opt-out uncovered while building them.

- **Writer (level 0)** emits DEFLATE *stored* blocks directly — no libdeflate
  call, no intermediate `BytesMut`, framing assembled in place in the reusable
  output buffer.
- **Reader** detects a single final stored block and reads it straight into its
  decompressed buffer, bypassing libdeflate and the staging copy. Incompressible
  data (which deflate stores even at higher levels) benefits automatically.
- **`Reader::with_crc_validation(false)`** skips the per-block CRC32 pass for
  faster reads of trusted, transient uncompressed streams. Validation stays **on
  by default**, and the cheap structural checks (block framing, ISIZE agreement)
  still run regardless.

## Fixes (bundled, same code paths)

- Reject blocks whose footer ISIZE exceeds the max BGZF block size
  (`BgzfError::UncompressedSizeExceeded`) instead of indexing past the buffer.
- Reject blocks smaller than header + footer.
- Prevent a `u16` `BSIZE` overflow in `Compressor::compress` for
  near-incompressible blocks (previously panicked in debug / wrote a corrupt
  size in release).
- Reject `blocksize == 0` in `Writer::with_capacity` (previously looped forever).

## ⚠️ Behavior change

A **truncated / partial trailing block is now reported as an error** rather than
silently treated as end-of-input. A stream that ends cleanly on a block boundary
(missing EOF marker) is still tolerated. This is stricter and more correct, but
downstream code relying on lenient trailing-junk tolerance will now see an error.

## API additions (all non-breaking)

- `Reader::with_crc_validation(bool)` (builder, `#[must_use]`).
- `BgzfError::UncompressedSizeExceeded { found, max }` — `BgzfError` is
  `#[non_exhaustive]`.
- `CompressionLevel` now documents level 0 as "no compression" (stored blocks);
  the round-trip proptest now covers levels `0..=12` (previously `1..=11`,
  silently skipping both 0 and 12).

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --all-features --all-targets -D
  warnings`, and `cargo test` (22 unit + 7 doctests) all green.
- **Interop with htslib** (`bgzip`/`samtools`) checked both directions on a
  ~500 KB multi-block payload: htslib decodes our level-0 output and we decode
  htslib's, both byte-identical to the original. Our framing is the same size as
  htslib's; the only byte difference is the advisory XFL hint at offset 8.
- New benches: `reader`, `roundtrip`, `writer_store_only`, `reader_store_only`,
  `roundtrip_store_only`.