### PR TITLE
feat: per-instance multithreaded reader and writer (multithreading-simple)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,3 +66,6 @@ jobs:
 
       - name: Run tests
         run: cargo test --verbose
+
+      - name: Run tests (all features)
+        run: cargo test --all-features --verbose

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -46,6 +46,11 @@ jobs:
       - name: Run cargo clippy
         run: cargo clippy --all-features --all-targets -- -D warnings
 
+      - name: Check docs
+        run: cargo doc --all-features --no-deps
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+
   test:
     name: Test Suite
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `std::io::Read`/`Write` (and `BufRead`) interfaces as the single-threaded types. Decompressed
   output is byte-identical to `Reader`, and compressed output is byte-identical to `Writer`, at
   every worker count. The feature name distinguishes this per-instance model from a future
-  `multithreading-pooled` feature (one thread pool shared across many readers/writers). Adds an
-  optional `crossbeam-channel` dependency; the default build is unchanged.
+  `multithreading-pooled` feature (one thread pool shared across many readers/writers). Adds
+  optional `crossbeam-channel` (pool queues) and `oneshot` (per-block result handoff)
+  dependencies; the default build is unchanged.
   - Read-ahead/write-ahead depth is decoupled from worker count (channels and the recycled-buffer
     pool are sized to `worker_count.max(8)`), so a single-worker instance still pipelines instead
     of stalling on a synchronous per-block handoff.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Per-instance multithreaded reader and writer behind the optional `multithreading-simple`
+  feature: `MultithreadedReader` and `MultithreadedWriter` each own a dedicated pool of worker
+  threads that (de)compress blocks in parallel while preserving block order, exposing the same
+  `std::io::Read`/`Write` (and `BufRead`) interfaces as the single-threaded types. Decompressed
+  output is byte-identical to `Reader`, and compressed output is byte-identical to `Writer`, at
+  every worker count. The feature name distinguishes this per-instance model from a future
+  `multithreading-pooled` feature (one thread pool shared across many readers/writers). Adds an
+  optional `kanal` dependency; the default build is unchanged.
+  - Read-ahead/write-ahead depth is decoupled from worker count (channels and the recycled-buffer
+    pool are sized to `worker_count.max(8)`), so a single-worker instance still pipelines instead
+    of stalling on a synchronous per-block handoff.
+  - v1 note: the writer allocates one output buffer per block; compressed-buffer recycling is a
+    planned, benchmark-gated optimization.
 - Store-only (compression level 0) fast paths: `Writer` emits DEFLATE stored blocks directly
   (no libdeflate, no intermediate `BytesMut`), and `Reader` reads a single final stored block
   straight into its decompressed buffer, bypassing libdeflate. Reading incompressible data (which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   output is byte-identical to `Reader`, and compressed output is byte-identical to `Writer`, at
   every worker count. The feature name distinguishes this per-instance model from a future
   `multithreading-pooled` feature (one thread pool shared across many readers/writers). Adds an
-  optional `kanal` dependency; the default build is unchanged.
+  optional `crossbeam-channel` dependency; the default build is unchanged.
   - Read-ahead/write-ahead depth is decoupled from worker count (channels and the recycled-buffer
     pool are sized to `worker_count.max(8)`), so a single-worker instance still pipelines instead
     of stalling on a synchronous per-block handoff.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,10 @@
 name = "bgzf"
 version = "0.4.0"
 edition = "2021"
+rust-version = "1.85"
 authors = [
-    "Seth Stadick <seth@fulcrumgenomics.com>"
+    "Seth Stadick <seth@fulcrumgenomics.com>",
+    "Tim Fennell <tim@fulcrumgenomics.com>"
 ]
 license = "MIT"
 readme = "README.md"
@@ -49,3 +51,9 @@ harness = false
 name = "multithreaded"
 harness = false
 required-features = ["multithreading-simple"]
+
+# Build docs on docs.rs with all features so the feature-gated multithreaded types are
+# documented, and enable the `doc_cfg` feature badges (see `#![cfg_attr(docsrs, ...)]` in lib.rs).
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,18 @@ libdeflater = "1.0"
 thiserror = "1.0"
 
 # Channels for the per-instance multithreaded reader/writer. Optional: only the
-# `multithreading-simple` feature pulls it in, so the default build stays lean.
-# Narrowest sensible feature set: `std` is the only feature we need (and its only
-# non-trivial one) — the channels are thread-parking based, so `no_std` is a non-starter.
+# `multithreading-simple` feature pulls them in, so the default build stays lean.
+# Narrowest sensible feature set: `std` (thread-parking blocking recv) only.
+# crossbeam-channel carries the pool's MPMC channels; `oneshot` is a purpose-built,
+# cheaper single-message channel for the per-block result handoff.
 crossbeam-channel = { version = "0.5", default-features = false, features = ["std"], optional = true }
+oneshot = { version = "0.2", default-features = false, features = ["std"], optional = true }
 
 [features]
 # Each `MultithreadedReader`/`MultithreadedWriter` owns a dedicated pool of worker
 # threads (as opposed to a future `multithreading-pooled` feature that would share
 # one thread pool across many readers/writers).
-multithreading-simple = ["dep:crossbeam-channel"]
+multithreading-simple = ["dep:crossbeam-channel", "dep:oneshot"]
 
 [dev-dependencies]
 criterion = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,15 @@ thiserror = "1.0"
 
 # Channels for the per-instance multithreaded reader/writer. Optional: only the
 # `multithreading-simple` feature pulls it in, so the default build stays lean.
-kanal = { version = "0.1.1", optional = true }
+# Narrowest sensible feature set: `std` is the only feature we need (and its only
+# non-trivial one) — the channels are thread-parking based, so `no_std` is a non-starter.
+crossbeam-channel = { version = "0.5", default-features = false, features = ["std"], optional = true }
 
 [features]
 # Each `MultithreadedReader`/`MultithreadedWriter` owns a dedicated pool of worker
 # threads (as opposed to a future `multithreading-pooled` feature that would share
 # one thread pool across many readers/writers).
-multithreading-simple = ["dep:kanal"]
+multithreading-simple = ["dep:crossbeam-channel"]
 
 [dev-dependencies]
 criterion = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bgzf"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = [
     "Seth Stadick <seth@fulcrumgenomics.com>"
@@ -22,6 +22,15 @@ bytes = "1.9"
 libdeflater = "1.0"
 thiserror = "1.0"
 
+# Channels for the per-instance multithreaded reader/writer. Optional: only the
+# `multithreading-simple` feature pulls it in, so the default build stays lean.
+kanal = { version = "0.1.1", optional = true }
+
+[features]
+# Each `MultithreadedReader`/`MultithreadedWriter` owns a dedicated pool of worker
+# threads (as opposed to a future `multithreading-pooled` feature that would share
+# one thread pool across many readers/writers).
+multithreading-simple = ["dep:kanal"]
 
 [dev-dependencies]
 criterion = "0.5"
@@ -31,3 +40,8 @@ proptest = "1"
 [[bench]]
 name = "compression"
 harness = false
+
+[[bench]]
+name = "multithreaded"
+harness = false
+required-features = ["multithreading-simple"]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,31 @@ Bgzf is a multi-gzip format that adds an extra field to the header indicating ho
 
 Please see the generated [Rust Docs](https://docs.rs/bgzf).
 
+## Multithreading
+
+The default `Reader`/`Writer` are single-threaded. Enable the optional
+`multithreading-simple` feature to also get `MultithreadedReader` and
+`MultithreadedWriter`, which (de)compress blocks in parallel on a dedicated pool of
+worker threads while preserving block order:
+
+```toml
+[dependencies]
+bgzf = { version = "0.4", features = ["multithreading-simple"] }
+```
+
+```rust
+use std::num::NonZero;
+use bgzf::MultithreadedReader;
+
+let reader = MultithreadedReader::with_worker_count(NonZero::new(4).unwrap(), input);
+```
+
+Each reader/writer owns its own worker threads (hence *simple*), as distinguished from a
+future `multithreading-pooled` feature that would share one thread pool across many
+instances. Read-ahead/write-ahead depth is decoupled from the worker count, so even a
+single-worker instance pipelines rather than stalling. Decompressed output is byte-identical
+to `Reader`, and compressed output is byte-identical to `Writer`, at every worker count.
+
 ## Benchmarks
 
 Run the compression benchmarks with:
@@ -41,3 +66,11 @@ cargo bench
 This runs [Criterion](https://github.com/bheisler/criterion.rs) benchmarks measuring:
 - Single block compression at various levels
 - Writer throughput
+- Reader throughput and read/write round-trips (including store-only)
+
+The multithreaded reader/writer benchmarks (single-threaded vs. 1/2/4 workers) require the
+feature:
+
+```bash
+cargo bench --features multithreading-simple --bench multithreaded
+```

--- a/README.md
+++ b/README.md
@@ -43,9 +43,12 @@ bgzf = { version = "0.4", features = ["multithreading-simple"] }
 ```
 
 ```rust
+use std::fs::File;
 use std::num::NonZero;
 use bgzf::MultithreadedReader;
 
+// The inner reader is any `Read + Send + 'static` source — here, a BGZF file on disk.
+let input = File::open("example.bgzf")?;
 let reader = MultithreadedReader::with_worker_count(NonZero::new(4).unwrap(), input);
 ```
 

--- a/benches/multithreaded.rs
+++ b/benches/multithreaded.rs
@@ -1,0 +1,116 @@
+//! Benchmarks for the per-instance multithreaded reader/writer.
+//!
+//! The load-bearing comparison is **1-worker multithreaded vs single-threaded**: a
+//! 1-worker `MultithreadedReader` must not be *slower* than the single-threaded `Reader`.
+//! That is the regression guard for the read-ahead-depth decoupling (channels/pool sized to
+//! `worker_count.max(8)`, not `worker_count`); if the `MIN_BUFFERS` floor is ever removed the
+//! 1-worker numbers here will visibly regress.
+
+use std::io::{Cursor, Read, Write};
+use std::num::NonZero;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+
+use bgzf::{
+    CompressionLevel, MultithreadedReader, MultithreadedWriter, Reader, Writer, BGZF_BLOCK_SIZE,
+};
+
+/// Deterministic random ACGT bases — realistic genomic-ish data that deflate compresses ~4x.
+fn genomic(len: usize) -> Vec<u8> {
+    const BASES: &[u8] = b"ACGT";
+    let mut state: u64 = 0x0123_4567_89AB_CDEF;
+    let mut out = Vec::with_capacity(len);
+    while out.len() < len {
+        state = state.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+        out.push(BASES[((state >> 33) & 3) as usize]);
+    }
+    out
+}
+
+/// BGZF-compress `data` at `level` into an in-memory blob.
+fn make_bgzf(data: &[u8], level: u8) -> Vec<u8> {
+    let mut out = Vec::with_capacity(data.len());
+    let mut writer = Writer::new(&mut out, CompressionLevel::new(level).unwrap());
+    writer.write_all(data).unwrap();
+    writer.finish().unwrap();
+    out
+}
+
+const WORKER_COUNTS: [usize; 3] = [1, 2, 4];
+
+/// Decode a large multi-block stream: single-threaded vs multithreaded at several worker
+/// counts. `mt/1` is the one to watch — it must stay at or under `serial`.
+fn bench_reader(c: &mut Criterion) {
+    let size = BGZF_BLOCK_SIZE * 200; // ~13 MB uncompressed
+    let data = genomic(size);
+
+    for level in [0u8, 6] {
+        // Leak so each iteration can wrap a fresh, cheap `Cursor` without recompressing.
+        let blob: &'static [u8] = make_bgzf(&data, level).leak();
+
+        let mut group = c.benchmark_group(format!("mt_reader/level{level}"));
+        group.throughput(Throughput::Bytes(size as u64));
+
+        group.bench_function("serial", |b| {
+            b.iter(|| {
+                let mut out = Vec::with_capacity(size);
+                Reader::new(blob).read_to_end(&mut out).unwrap();
+                black_box(&out);
+            });
+        });
+
+        for workers in WORKER_COUNTS {
+            group.bench_function(format!("mt/{workers}"), |b| {
+                b.iter(|| {
+                    let mut out = Vec::with_capacity(size);
+                    MultithreadedReader::with_worker_count(
+                        NonZero::new(workers).unwrap(),
+                        Cursor::new(blob),
+                    )
+                    .read_to_end(&mut out)
+                    .unwrap();
+                    black_box(&out);
+                });
+            });
+        }
+        group.finish();
+    }
+}
+
+/// Compress a large input: single-threaded vs multithreaded at several worker counts.
+fn bench_writer(c: &mut Criterion) {
+    let size = BGZF_BLOCK_SIZE * 200; // ~13 MB
+    let data = genomic(size);
+
+    for level in [0u8, 6] {
+        let mut group = c.benchmark_group(format!("mt_writer/level{level}"));
+        group.throughput(Throughput::Bytes(size as u64));
+
+        group.bench_function("serial", |b| {
+            b.iter(|| {
+                let mut writer =
+                    Writer::new(Vec::with_capacity(size), CompressionLevel::new(level).unwrap());
+                writer.write_all(black_box(&data)).unwrap();
+                black_box(writer.finish().unwrap());
+            });
+        });
+
+        for workers in WORKER_COUNTS {
+            group.bench_function(format!("mt/{workers}"), |b| {
+                b.iter(|| {
+                    let mut writer = MultithreadedWriter::with_worker_count(
+                        NonZero::new(workers).unwrap(),
+                        Vec::with_capacity(size),
+                        CompressionLevel::new(level).unwrap(),
+                    );
+                    writer.write_all(black_box(&data)).unwrap();
+                    black_box(writer.finish().unwrap());
+                });
+            });
+        }
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_reader, bench_writer);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,17 @@
 //!     Ok(())
 //! }
 //! ```
+//!
+//! # Multithreading
+//!
+//! The [`Reader`] and [`Writer`] above are single-threaded. Enabling the optional
+//! `multithreading-simple` feature adds `MultithreadedReader` and `MultithreadedWriter`, which
+//! (de)compress blocks in parallel on a dedicated pool of worker threads while preserving block
+//! order, exposing the same [`std::io::Read`]/[`std::io::Write`] interfaces. Each reader/writer
+//! owns its own worker threads — hence *simple* — as distinguished from a possible future
+//! `multithreading-pooled` feature that would share one thread pool across many readers/writers.
 #![deny(unsafe_code)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::must_use_candidate, clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 // Re-export the reader and writer to the same level.
@@ -37,8 +47,10 @@ mod multithreaded_reader;
 #[cfg(feature = "multithreading-simple")]
 mod multithreaded_writer;
 #[cfg(feature = "multithreading-simple")]
+#[cfg_attr(docsrs, doc(cfg(feature = "multithreading-simple")))]
 pub use multithreaded_reader::*;
 #[cfg(feature = "multithreading-simple")]
+#[cfg_attr(docsrs, doc(cfg(feature = "multithreading-simple")))]
 pub use multithreaded_writer::*;
 
 use std::io;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,18 @@ mod writer;
 pub use reader::*;
 pub use writer::*;
 
+// Per-instance multithreaded reader/writer: each owns a dedicated pool of worker
+// threads. Gated behind `multithreading-simple` so the channel dependency and the
+// threading machinery are absent from the default build.
+#[cfg(feature = "multithreading-simple")]
+mod multithreaded_reader;
+#[cfg(feature = "multithreading-simple")]
+mod multithreaded_writer;
+#[cfg(feature = "multithreading-simple")]
+pub use multithreaded_reader::*;
+#[cfg(feature = "multithreading-simple")]
+pub use multithreaded_writer::*;
+
 use std::io;
 
 use byteorder::{ByteOrder, LittleEndian};

--- a/src/multithreaded_reader.rs
+++ b/src/multithreaded_reader.rs
@@ -8,7 +8,8 @@
 //!
 //! # Design
 //!
-//! Three roles connected by `crossbeam-channel` channels, modelled on noodles-bgzf's
+//! Three roles connected by channels — `crossbeam-channel` for the pool's MPMC queues and a
+//! purpose-built `oneshot` per block for the result handoff — modelled on noodles-bgzf's
 //! `MultithreadedReader` but using this crate's block internals:
 //!
 //! - **Reader thread** — reads raw blocks (header + payload + footer) in file order,
@@ -71,11 +72,12 @@ struct Buffer {
     pos: usize,
 }
 
-// A per-block "one-shot": the worker sends the decoded (or failed) buffer back on it, and
-// the consumer — holding the matching receiver, pulled in file order — waits on it.
+// A per-block "one-shot": the worker sends the decoded (or failed) buffer back on it, and the
+// consumer — holding the matching receiver, pulled in file order — waits on it. A purpose-built
+// single-message `oneshot` channel is cheaper here than a general MPMC `bounded(1)`.
 type Decoded = io::Result<Buffer>;
-type DecodedTx = Sender<Decoded>;
-type DecodedRx = Receiver<Decoded>;
+type DecodedTx = oneshot::Sender<Decoded>;
+type DecodedRx = oneshot::Receiver<Decoded>;
 // Reader → workers: a raw block plus the one-shot to answer on.
 type InflateTx = Sender<(Buffer, DecodedTx)>;
 type InflateRx = Receiver<(Buffer, DecodedTx)>;
@@ -300,7 +302,7 @@ where
             match read_raw_block(&mut reader, &mut buffer) {
                 Ok(false) => break, // clean end of stream at a block boundary
                 Ok(true) => {
-                    let (decoded_tx, decoded_rx) = bounded::<Decoded>(1);
+                    let (decoded_tx, decoded_rx) = oneshot::channel::<Decoded>();
                     // Dispatch to a worker, then register the slot with the consumer. If
                     // either channel is closed we are shutting down, so stop.
                     if inflate_tx.send((buffer, decoded_tx)).is_err()
@@ -311,7 +313,7 @@ where
                 }
                 Err(e) => {
                     // Surface the error to the consumer in order, then stop.
-                    let (decoded_tx, decoded_rx) = bounded::<Decoded>(1);
+                    let (decoded_tx, decoded_rx) = oneshot::channel::<Decoded>();
                     decoded_tx.send(Err(e)).ok();
                     order_tx.send(decoded_rx).ok();
                     break;

--- a/src/multithreaded_reader.rs
+++ b/src/multithreaded_reader.rs
@@ -48,15 +48,26 @@ use crate::{
 /// `worker_count.max(MIN_BUFFERS)` so even a single-worker reader reads ahead.
 const MIN_BUFFERS: usize = 8;
 
-/// A recycled unit of work that cycles reader → worker → consumer → reader with no
-/// per-block allocation.
+/// A recycled unit of work that cycles reader → worker → consumer → reader with no per-block
+/// allocation.
+///
+/// `raw` and `data` are reused across blocks and only ever grow — their `Vec` length is a
+/// high-water mark, and the live bytes are `raw[..raw_len]` / `data[..data_len]`. Tracking the
+/// live length separately (rather than resizing the `Vec` each block) means the payload and
+/// decompressed regions are never re-zeroed per block; the only zero-fill is the one-time growth
+/// to the high-water mark during warm-up.
 #[derive(Default)]
 struct Buffer {
-    /// Raw block bytes: the 18-byte BGZF header + payload (deflate stream + 8-byte footer).
+    /// Backing store for raw block bytes (18-byte BGZF header + payload + 8-byte footer). The
+    /// current block is `raw[..raw_len]`.
     raw: Vec<u8>,
-    /// Decompressed block contents.
+    /// Length of the current raw block within `raw`.
+    raw_len: usize,
+    /// Backing store for decompressed bytes. The current block is `data[..data_len]`.
     data: Vec<u8>,
-    /// Consumer read cursor into `data`.
+    /// Length of the current decompressed block within `data`.
+    data_len: usize,
+    /// Consumer read cursor into `data[..data_len]`.
     pos: usize,
 }
 
@@ -194,15 +205,14 @@ where
                 io::Error::new(io::ErrorKind::Other, "bgzf worker thread stopped")
             })??;
 
-            // Swap the new block in and recycle the one we just finished serving.
-            let mut spent = std::mem::replace(&mut self.buffer, buffer);
+            // Swap the new block in and recycle the one we just finished serving. The spent
+            // buffer keeps its (high-water) length and capacity so the next block reuses them
+            // without re-zeroing; its `raw_len`/`data_len`/`pos` are set when it is refilled.
+            let spent = std::mem::replace(&mut self.buffer, buffer);
             self.buffer.pos = 0;
-            spent.raw.clear();
-            spent.data.clear();
-            spent.pos = 0;
             recycle_tx.send(spent).ok();
 
-            if !self.buffer.data.is_empty() {
+            if self.buffer.data_len > 0 {
                 return Ok(true);
             }
         }
@@ -216,10 +226,10 @@ where
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut copied = 0;
         while copied < buf.len() {
-            if self.buffer.pos >= self.buffer.data.len() && !self.next_block()? {
+            if self.buffer.pos >= self.buffer.data_len && !self.next_block()? {
                 break;
             }
-            let available = &self.buffer.data[self.buffer.pos..];
+            let available = &self.buffer.data[self.buffer.pos..self.buffer.data_len];
             let n = available.len().min(buf.len() - copied);
             buf[copied..copied + n].copy_from_slice(&available[..n]);
             self.buffer.pos += n;
@@ -234,14 +244,14 @@ where
     R: Read + Send + 'static,
 {
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
-        if self.buffer.pos >= self.buffer.data.len() {
+        if self.buffer.pos >= self.buffer.data_len {
             self.next_block()?;
         }
-        Ok(&self.buffer.data[self.buffer.pos..])
+        Ok(&self.buffer.data[self.buffer.pos..self.buffer.data_len])
     }
 
     fn consume(&mut self, amt: usize) {
-        self.buffer.pos = (self.buffer.pos + amt).min(self.buffer.data.len());
+        self.buffer.pos = (self.buffer.pos + amt).min(self.buffer.data_len);
     }
 }
 
@@ -287,7 +297,7 @@ where
 {
     thread::spawn(move || {
         while let Ok(mut buffer) = recycle_rx.recv() {
-            match read_raw_block(&mut reader, &mut buffer.raw) {
+            match read_raw_block(&mut reader, &mut buffer) {
                 Ok(false) => break, // clean end of stream at a block boundary
                 Ok(true) => {
                     let (decoded_tx, decoded_rx) = bounded::<Decoded>(1);
@@ -320,45 +330,76 @@ fn spawn_inflaters(worker_count: usize, inflate_rx: InflateRx) -> Vec<JoinHandle
             thread::spawn(move || {
                 let mut decompressor = Decompressor::new();
                 while let Ok((mut buffer, decoded_tx)) = inflate_rx.recv() {
-                    let result = decode_block(&buffer.raw, &mut decompressor, &mut buffer.data)
-                        .map(|()| buffer);
-                    decoded_tx.send(result).ok();
+                    // `raw` and `data` are disjoint fields, so these borrows don't conflict.
+                    let result = decode_block(
+                        &buffer.raw[..buffer.raw_len],
+                        &mut buffer.data,
+                        &mut decompressor,
+                    );
+                    let message = match result {
+                        Ok(data_len) => {
+                            buffer.data_len = data_len;
+                            buffer.pos = 0;
+                            Ok(buffer)
+                        }
+                        Err(e) => Err(e),
+                    };
+                    decoded_tx.send(message).ok();
                 }
             })
         })
         .collect()
 }
 
-/// Read one raw BGZF block (header + payload + footer) into `raw`.
+/// Grow `buf` so that `buf[..len]` is a valid slice to write into.
+///
+/// The `Vec` length is a high-water mark that only grows and is never shrunk, so only the growth
+/// beyond the previous mark is ever zero-filled — a block at or below the mark reuses
+/// already-initialized bytes and does no memset.
+#[inline]
+fn grow_to(buf: &mut Vec<u8>, len: usize) {
+    if buf.len() < len {
+        buf.resize(len, 0);
+    }
+}
+
+/// Read one raw BGZF block (header + payload + footer) into `buffer.raw`, setting `buffer.raw_len`.
 ///
 /// Returns `Ok(true)` when a block was read, `Ok(false)` on a clean end of stream at a block
-/// boundary, and an error for a truncated or malformed block. Only the header is validated
-/// here (matching the single-threaded reader); the footer and payload are validated by the
-/// worker that decodes the block.
-fn read_raw_block<R: Read>(reader: &mut R, raw: &mut Vec<u8>) -> io::Result<bool> {
-    raw.resize(BGZF_HEADER_SIZE, 0);
-    if !read_full(reader, &mut raw[..BGZF_HEADER_SIZE])? {
+/// boundary, and an error for a truncated or malformed block. Only the header is validated here
+/// (matching the single-threaded reader); the footer and payload are validated by the worker that
+/// decodes the block.
+fn read_raw_block<R: Read>(reader: &mut R, buffer: &mut Buffer) -> io::Result<bool> {
+    let mut header = [0u8; BGZF_HEADER_SIZE];
+    if !read_full(reader, &mut header)? {
         return Ok(false);
     }
-    check_header(&raw[..BGZF_HEADER_SIZE]).map_err(to_io)?;
+    check_header(&header).map_err(to_io)?;
 
-    let block_size = get_block_size(&raw[..BGZF_HEADER_SIZE]);
+    let block_size = get_block_size(&header);
     if block_size < BGZF_HEADER_SIZE + BGZF_FOOTER_SIZE {
         return Err(to_io(BgzfError::InvalidHeader("block size smaller than header plus footer")));
     }
 
-    raw.resize(block_size, 0);
-    reader.read_exact(&mut raw[BGZF_HEADER_SIZE..])?;
+    grow_to(&mut buffer.raw, block_size);
+    buffer.raw[..BGZF_HEADER_SIZE].copy_from_slice(&header);
+    reader.read_exact(&mut buffer.raw[BGZF_HEADER_SIZE..block_size])?;
+    buffer.raw_len = block_size;
     Ok(true)
 }
 
-/// Decode one raw BGZF block into `out`, replacing its contents.
+/// Decode one raw BGZF block into `data`, returning the number of decompressed bytes written (the
+/// block occupies `data[..returned]`).
 ///
-/// Mirrors the single-threaded reader's per-block path: a single final stored block is
-/// copied verbatim (skipping libdeflate), anything else is inflated. In both cases the
-/// uncompressed size is checked against the footer's ISIZE and the CRC32 is verified.
-fn decode_block(raw: &[u8], decompressor: &mut Decompressor, out: &mut Vec<u8>) -> io::Result<()> {
-    out.clear();
+/// Mirrors the single-threaded reader's per-block path: a single final stored block is copied
+/// verbatim (skipping libdeflate), anything else is inflated. In both cases the uncompressed size
+/// is checked against the footer's ISIZE and the CRC32 is verified. `data` grows to a high-water
+/// mark and is written in place, so nothing is re-zeroed per block.
+fn decode_block(
+    raw: &[u8],
+    data: &mut Vec<u8>,
+    decompressor: &mut Decompressor,
+) -> io::Result<usize> {
     // Everything after the 18-byte header: the deflate stream followed by the 8-byte footer.
     // `read_raw_block` guarantees `raw.len() >= BGZF_HEADER_SIZE + BGZF_FOOTER_SIZE`.
     let payload = &raw[BGZF_HEADER_SIZE..];
@@ -374,25 +415,29 @@ fn decode_block(raw: &[u8], decompressor: &mut Decompressor, out: &mut Vec<u8>) 
                     "stored block length disagrees with footer",
                 )));
             }
-            let data = &payload[DEFLATE_STORED_HEADER_SIZE..DEFLATE_STORED_HEADER_SIZE + len];
-            let found = crc32(data);
+            let src = &payload[DEFLATE_STORED_HEADER_SIZE..DEFLATE_STORED_HEADER_SIZE + len];
+            let found = crc32(src);
             if found != check.sum {
                 return Err(to_io(BgzfError::InvalidChecksum { found, expected: check.sum }));
             }
-            out.extend_from_slice(data);
-            return Ok(());
+            grow_to(data, len);
+            data[..len].copy_from_slice(src);
+            return Ok(len);
         }
     }
 
-    // Inflate path. Guard the claimed size against the maximum block size before allocating.
+    // Inflate path. Guard the claimed size against the maximum block size before growing.
     if expected_len > MAX_BGZF_BLOCK_SIZE {
         return Err(to_io(BgzfError::UncompressedSizeExceeded {
             found: expected_len,
             max: MAX_BGZF_BLOCK_SIZE,
         }));
     }
-    out.resize(expected_len, 0);
-    decompressor.decompress(strip_footer(payload), out, check, true).map_err(to_io)
+    grow_to(data, expected_len);
+    decompressor
+        .decompress(strip_footer(payload), &mut data[..expected_len], check, true)
+        .map_err(to_io)?;
+    Ok(expected_len)
 }
 
 #[cfg(test)]

--- a/src/multithreaded_reader.rs
+++ b/src/multithreaded_reader.rs
@@ -1,0 +1,598 @@
+//! A per-instance multithreaded BGZF reader.
+//!
+//! [`MultithreadedReader`] decompresses BGZF blocks on a pool of worker threads it
+//! owns, while presenting a plain [`std::io::Read`] (and [`std::io::BufRead`]) to the
+//! caller. It is a drop-in, higher-throughput alternative to the single-threaded
+//! [`Reader`](crate::Reader) for large, sequential streams; its decompressed output is
+//! byte-identical to `Reader`'s at every worker count.
+//!
+//! # Design
+//!
+//! Three roles connected by [`kanal`] channels, modelled on noodles-bgzf's
+//! `MultithreadedReader` but using this crate's block internals:
+//!
+//! - **Reader thread** — reads raw blocks (header + payload + footer) in file order,
+//!   pulling a recycled buffer from a pool, and dispatches each to the worker pool while
+//!   registering its slot with the consumer so order is preserved.
+//! - **Inflater workers** — decompress blocks in parallel using the same logic as the
+//!   single-threaded reader (stored-block fast path, else libdeflate; CRC32-verified).
+//! - **Consumer** (the `Read` impl) — pulls decompressed blocks *in file order*, serves
+//!   their bytes, and returns spent buffers to the pool.
+//!
+//! ## Read-ahead depth is decoupled from worker count
+//!
+//! All channels *and* the recycled-buffer pool are sized to
+//! `worker_count.max(MIN_BUFFERS)`, never to `worker_count` alone. Sizing to the worker
+//! count would leave a single-worker reader with depth-1 lookahead — the reader thread
+//! and the inflater could not overlap with the consumer, and every block would be a
+//! synchronous handoff. That makes a 1-worker multithreaded reader *slower* than the
+//! single-threaded [`Reader`](crate::Reader); the `MIN_BUFFERS` floor is what prevents it.
+//!
+//! Seeking is intentionally out of scope: this reader is sequential only. A
+//! `Seek`/virtual-position implementation could be layered on later for indexed reads.
+
+use std::io::{self, BufRead, Read};
+use std::num::NonZero;
+use std::thread::{self, JoinHandle};
+
+use kanal::{bounded, Receiver, Sender};
+
+use crate::reader::read_full;
+use crate::{
+    check_header, crc32, get_block_size, get_footer_values, stored_block_len, strip_footer,
+    BgzfError, Decompressor, BGZF_FOOTER_SIZE, BGZF_HEADER_SIZE, DEFLATE_STORED_HEADER_SIZE,
+    MAX_BGZF_BLOCK_SIZE,
+};
+
+/// Read-ahead depth floor. See the module docs: channels and the buffer pool are sized to
+/// `worker_count.max(MIN_BUFFERS)` so even a single-worker reader reads ahead.
+const MIN_BUFFERS: usize = 8;
+
+/// A recycled unit of work that cycles reader → worker → consumer → reader with no
+/// per-block allocation.
+#[derive(Default)]
+struct Buffer {
+    /// Raw block bytes: the 18-byte BGZF header + payload (deflate stream + 8-byte footer).
+    raw: Vec<u8>,
+    /// Decompressed block contents.
+    data: Vec<u8>,
+    /// Consumer read cursor into `data`.
+    pos: usize,
+}
+
+// A per-block "one-shot": the worker sends the decoded (or failed) buffer back on it, and
+// the consumer — holding the matching receiver, pulled in file order — waits on it.
+type Decoded = io::Result<Buffer>;
+type DecodedTx = Sender<Decoded>;
+type DecodedRx = Receiver<Decoded>;
+// Reader → workers: a raw block plus the one-shot to answer on.
+type InflateTx = Sender<(Buffer, DecodedTx)>;
+type InflateRx = Receiver<(Buffer, DecodedTx)>;
+// Reader → consumer: the one-shot receivers, in file order.
+type OrderTx = Sender<DecodedRx>;
+type OrderRx = Receiver<DecodedRx>;
+// Consumer → reader: spent buffers to reuse.
+type RecycleTx = Sender<Buffer>;
+type RecycleRx = Receiver<Buffer>;
+
+enum State<R> {
+    Running {
+        reader_handle: JoinHandle<R>,
+        inflater_handles: Vec<JoinHandle<()>>,
+        order_rx: OrderRx,
+        recycle_tx: RecycleTx,
+    },
+    Done,
+}
+
+/// A multithreaded BGZF reader.
+///
+/// Decompresses blocks on a dedicated pool of worker threads while exposing a sequential
+/// [`Read`]/[`BufRead`] interface. See the [module docs](self) for the design.
+///
+/// The worker threads are joined when the reader is dropped; call [`finish`](Self::finish)
+/// instead if you need to observe reader-thread panics or reclaim the inner reader.
+///
+/// # Example
+///
+/// ```rust
+/// # #[cfg(feature = "multithreading-simple")] {
+/// use std::io::Read;
+/// use bgzf::MultithreadedReader;
+/// # let compressed: &[u8] = &[];
+/// let mut reader = MultithreadedReader::new(compressed);
+/// let mut bytes = vec![];
+/// reader.read_to_end(&mut bytes).unwrap();
+/// # }
+/// ```
+pub struct MultithreadedReader<R>
+where
+    R: Read + Send + 'static,
+{
+    state: State<R>,
+    /// The block currently being served to the caller.
+    buffer: Buffer,
+}
+
+impl<R> MultithreadedReader<R>
+where
+    R: Read + Send + 'static,
+{
+    /// Create a reader with a worker count derived from the available parallelism.
+    pub fn new(inner: R) -> Self {
+        let workers = thread::available_parallelism().map_or(1, NonZero::get);
+        Self::with_worker_count(NonZero::new(workers).unwrap_or(NonZero::<usize>::MIN), inner)
+    }
+
+    /// Create a reader with the given number of inflater worker threads.
+    ///
+    /// The read-ahead depth is `worker_count.max(8)` regardless of `worker_count`, so a
+    /// single-worker reader still reads ahead (see the [module docs](self)).
+    pub fn with_worker_count(worker_count: NonZero<usize>, inner: R) -> Self {
+        let capacity = worker_count.get().max(MIN_BUFFERS);
+
+        let (inflate_tx, inflate_rx) = bounded::<(Buffer, DecodedTx)>(capacity);
+        let (order_tx, order_rx) = bounded::<DecodedRx>(capacity);
+        let (recycle_tx, recycle_rx) = bounded::<Buffer>(capacity);
+
+        // Seed the pool. `capacity` buffers cycle through the pipeline; together with the
+        // one the consumer holds, exactly `capacity + 1` buffers ever exist, so the
+        // `bounded(capacity)` recycle channel never overflows (the consumer always holds
+        // one out). The reader thread always ends up blocked on `recycle_rx` when the
+        // consumer stalls — which is why dropping `recycle_tx` is sufficient for shutdown.
+        for _ in 0..capacity {
+            recycle_tx.send(Buffer::default()).expect("seeding the recycle pool cannot fail");
+        }
+
+        let reader_handle = spawn_reader(inner, inflate_tx, order_tx, recycle_rx);
+        let inflater_handles = spawn_inflaters(worker_count.get(), inflate_rx);
+
+        Self {
+            state: State::Running { reader_handle, inflater_handles, order_rx, recycle_tx },
+            buffer: Buffer::default(),
+        }
+    }
+
+    /// Shut the reader down and return the inner reader.
+    ///
+    /// Joins the worker threads and the reader thread. Unlike letting the reader drop, this
+    /// surfaces a panic in any worker as an error. Errors from decoding blocks are reported
+    /// through [`read`](Read::read) as they are encountered, not here.
+    pub fn finish(&mut self) -> io::Result<R> {
+        match std::mem::replace(&mut self.state, State::Done) {
+            State::Running { reader_handle, mut inflater_handles, order_rx, recycle_tx } => {
+                // Signal shutdown: with no more recycled buffers coming and no consumer for
+                // the order channel, the reader thread breaks out of its loop, drops its
+                // channel ends, and returns; the workers then see their input close.
+                drop(recycle_tx);
+                drop(order_rx);
+
+                for handle in inflater_handles.drain(..) {
+                    handle.join().map_err(|_| thread_panicked("inflater"))?;
+                }
+                reader_handle.join().map_err(|_| thread_panicked("reader"))
+            }
+            State::Done => Err(io::Error::new(io::ErrorKind::Other, "reader already finished")),
+        }
+    }
+
+    /// Advance [`self.buffer`](Self::buffer) to the next non-empty decompressed block.
+    ///
+    /// Returns `Ok(true)` when a block is ready, `Ok(false)` at end of stream. Empty blocks
+    /// (e.g. the BGZF EOF marker) are transparently skipped. Decode errors — and read or
+    /// header errors surfaced by the reader thread — are returned here, in file order.
+    fn next_block(&mut self) -> io::Result<bool> {
+        let State::Running { order_rx, recycle_tx, .. } = &self.state else {
+            return Ok(false);
+        };
+        loop {
+            // Next block's one-shot, in file order; a closed channel means end of stream.
+            let Ok(decoded_rx) = order_rx.recv() else {
+                return Ok(false);
+            };
+            let buffer = decoded_rx.recv().map_err(|_| {
+                io::Error::new(io::ErrorKind::Other, "bgzf worker thread stopped")
+            })??;
+
+            // Swap the new block in and recycle the one we just finished serving.
+            let mut spent = std::mem::replace(&mut self.buffer, buffer);
+            self.buffer.pos = 0;
+            spent.raw.clear();
+            spent.data.clear();
+            spent.pos = 0;
+            recycle_tx.send(spent).ok();
+
+            if !self.buffer.data.is_empty() {
+                return Ok(true);
+            }
+        }
+    }
+}
+
+impl<R> Read for MultithreadedReader<R>
+where
+    R: Read + Send + 'static,
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut copied = 0;
+        while copied < buf.len() {
+            if self.buffer.pos >= self.buffer.data.len() && !self.next_block()? {
+                break;
+            }
+            let available = &self.buffer.data[self.buffer.pos..];
+            let n = available.len().min(buf.len() - copied);
+            buf[copied..copied + n].copy_from_slice(&available[..n]);
+            self.buffer.pos += n;
+            copied += n;
+        }
+        Ok(copied)
+    }
+}
+
+impl<R> BufRead for MultithreadedReader<R>
+where
+    R: Read + Send + 'static,
+{
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        if self.buffer.pos >= self.buffer.data.len() {
+            self.next_block()?;
+        }
+        Ok(&self.buffer.data[self.buffer.pos..])
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.buffer.pos = (self.buffer.pos + amt).min(self.buffer.data.len());
+    }
+}
+
+impl<R> Drop for MultithreadedReader<R>
+where
+    R: Read + Send + 'static,
+{
+    fn drop(&mut self) {
+        if matches!(self.state, State::Running { .. }) {
+            let _ = self.finish();
+        }
+    }
+}
+
+impl MultithreadedReader<std::fs::File> {
+    /// Create a multithreaded reader over a file at `path`.
+    pub fn from_path<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+        std::fs::File::open(path).map(Self::new)
+    }
+}
+
+fn thread_panicked(which: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, format!("bgzf {which} thread panicked"))
+}
+
+fn to_io(e: BgzfError) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, e)
+}
+
+/// The reader thread: read raw blocks in file order and dispatch them to the worker pool.
+///
+/// Read/format errors are pushed down the ordered one-shot pipeline so the consumer sees
+/// them at the right point (matching the single-threaded reader), then the thread stops.
+/// A clean end-of-stream at a block boundary simply ends the loop.
+fn spawn_reader<R>(
+    mut reader: R,
+    inflate_tx: InflateTx,
+    order_tx: OrderTx,
+    recycle_rx: RecycleRx,
+) -> JoinHandle<R>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        while let Ok(mut buffer) = recycle_rx.recv() {
+            match read_raw_block(&mut reader, &mut buffer.raw) {
+                Ok(false) => break, // clean end of stream at a block boundary
+                Ok(true) => {
+                    let (decoded_tx, decoded_rx) = bounded::<Decoded>(1);
+                    // Dispatch to a worker, then register the slot with the consumer. If
+                    // either channel is closed we are shutting down, so stop.
+                    if inflate_tx.send((buffer, decoded_tx)).is_err()
+                        || order_tx.send(decoded_rx).is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    // Surface the error to the consumer in order, then stop.
+                    let (decoded_tx, decoded_rx) = bounded::<Decoded>(1);
+                    decoded_tx.send(Err(e)).ok();
+                    order_tx.send(decoded_rx).ok();
+                    break;
+                }
+            }
+        }
+        reader
+    })
+}
+
+/// The inflater workers: decode raw blocks into their buffers and answer their one-shots.
+fn spawn_inflaters(worker_count: usize, inflate_rx: InflateRx) -> Vec<JoinHandle<()>> {
+    (0..worker_count)
+        .map(|_| {
+            let inflate_rx = inflate_rx.clone();
+            thread::spawn(move || {
+                let mut decompressor = Decompressor::new();
+                while let Ok((mut buffer, decoded_tx)) = inflate_rx.recv() {
+                    let result = decode_block(&buffer.raw, &mut decompressor, &mut buffer.data)
+                        .map(|()| buffer);
+                    decoded_tx.send(result).ok();
+                }
+            })
+        })
+        .collect()
+}
+
+/// Read one raw BGZF block (header + payload + footer) into `raw`.
+///
+/// Returns `Ok(true)` when a block was read, `Ok(false)` on a clean end of stream at a block
+/// boundary, and an error for a truncated or malformed block. Only the header is validated
+/// here (matching the single-threaded reader); the footer and payload are validated by the
+/// worker that decodes the block.
+fn read_raw_block<R: Read>(reader: &mut R, raw: &mut Vec<u8>) -> io::Result<bool> {
+    raw.resize(BGZF_HEADER_SIZE, 0);
+    if !read_full(reader, &mut raw[..BGZF_HEADER_SIZE])? {
+        return Ok(false);
+    }
+    check_header(&raw[..BGZF_HEADER_SIZE]).map_err(to_io)?;
+
+    let block_size = get_block_size(&raw[..BGZF_HEADER_SIZE]);
+    if block_size < BGZF_HEADER_SIZE + BGZF_FOOTER_SIZE {
+        return Err(to_io(BgzfError::InvalidHeader("block size smaller than header plus footer")));
+    }
+
+    raw.resize(block_size, 0);
+    reader.read_exact(&mut raw[BGZF_HEADER_SIZE..])?;
+    Ok(true)
+}
+
+/// Decode one raw BGZF block into `out`, replacing its contents.
+///
+/// Mirrors the single-threaded reader's per-block path: a single final stored block is
+/// copied verbatim (skipping libdeflate), anything else is inflated. In both cases the
+/// uncompressed size is checked against the footer's ISIZE and the CRC32 is verified.
+fn decode_block(raw: &[u8], decompressor: &mut Decompressor, out: &mut Vec<u8>) -> io::Result<()> {
+    out.clear();
+    // Everything after the 18-byte header: the deflate stream followed by the 8-byte footer.
+    // `read_raw_block` guarantees `raw.len() >= BGZF_HEADER_SIZE + BGZF_FOOTER_SIZE`.
+    let payload = &raw[BGZF_HEADER_SIZE..];
+    let check = get_footer_values(payload);
+    let expected_len = check.amount as usize;
+
+    // Fast path: a single final stored block whose framing spans the whole payload holds its
+    // bytes verbatim. Copy them out, skipping libdeflate, then verify size and CRC.
+    if let Some(len) = stored_block_len(payload) {
+        if payload.len() == DEFLATE_STORED_HEADER_SIZE + len + BGZF_FOOTER_SIZE {
+            if len != expected_len {
+                return Err(to_io(BgzfError::InvalidHeader(
+                    "stored block length disagrees with footer",
+                )));
+            }
+            let data = &payload[DEFLATE_STORED_HEADER_SIZE..DEFLATE_STORED_HEADER_SIZE + len];
+            let found = crc32(data);
+            if found != check.sum {
+                return Err(to_io(BgzfError::InvalidChecksum { found, expected: check.sum }));
+            }
+            out.extend_from_slice(data);
+            return Ok(());
+        }
+    }
+
+    // Inflate path. Guard the claimed size against the maximum block size before allocating.
+    if expected_len > MAX_BGZF_BLOCK_SIZE {
+        return Err(to_io(BgzfError::UncompressedSizeExceeded {
+            found: expected_len,
+            max: MAX_BGZF_BLOCK_SIZE,
+        }));
+    }
+    out.resize(expected_len, 0);
+    decompressor.decompress(strip_footer(payload), out, check, true).map_err(to_io)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Cursor, Read, Write};
+
+    use crate::{CompressionLevel, Reader, Writer};
+
+    use super::*;
+
+    /// An owned, `'static + Send` reader over `blob` — what `MultithreadedReader` requires.
+    fn owned(blob: &[u8]) -> Cursor<Vec<u8>> {
+        Cursor::new(blob.to_vec())
+    }
+
+    /// BGZF-compress `data` at `level` into an in-memory blob.
+    fn make_bgzf(data: &[u8], level: u8) -> Vec<u8> {
+        let mut out = vec![];
+        let mut writer = Writer::new(&mut out, CompressionLevel::new(level).unwrap());
+        writer.write_all(data).unwrap();
+        writer.finish().unwrap();
+        out
+    }
+
+    /// A deterministic, multi-block payload (spans well over 64 KiB).
+    fn sample(len: usize) -> Vec<u8> {
+        (0..len as u32).map(|i| i.wrapping_mul(2_654_435_761).rotate_left(13) as u8).collect()
+    }
+
+    fn read_serial(blob: &[u8]) -> Vec<u8> {
+        let mut out = vec![];
+        Reader::new(blob).read_to_end(&mut out).unwrap();
+        out
+    }
+
+    fn read_mt(blob: &[u8], workers: usize) -> Vec<u8> {
+        let mut out = vec![];
+        MultithreadedReader::with_worker_count(NonZero::new(workers).unwrap(), owned(blob))
+            .read_to_end(&mut out)
+            .unwrap();
+        out
+    }
+
+    /// The multithreaded reader must produce byte-identical output to the single-threaded
+    /// reader for the same input, at every worker count.
+    #[test]
+    fn matches_single_threaded_at_each_worker_count() {
+        let input = sample(300_000); // several blocks
+        for level in [0u8, 1, 6] {
+            let blob = make_bgzf(&input, level);
+            let serial = read_serial(&blob);
+            assert_eq!(serial, input, "sanity: serial reader round-trips at level {level}");
+            for workers in [1usize, 2, 4, 8] {
+                assert_eq!(
+                    read_mt(&blob, workers),
+                    input,
+                    "mt reader diverged at level {level}, {workers} workers"
+                );
+            }
+        }
+    }
+
+    /// An explicit single-worker test: the depth-decoupling design must still be correct
+    /// (not just fast) with one worker.
+    #[test]
+    fn single_worker_round_trips() {
+        let input = sample(200_000);
+        let blob = make_bgzf(&input, 6);
+        assert_eq!(read_mt(&blob, 1), input);
+    }
+
+    /// Store-only (level 0) multi-block streams exercise the stored-block fast path in the
+    /// workers.
+    #[test]
+    fn store_only_multi_block_round_trips() {
+        let input = sample(250_000);
+        let blob = make_bgzf(&input, 0);
+        for workers in [1usize, 3] {
+            assert_eq!(read_mt(&blob, workers), input);
+        }
+    }
+
+    /// Empty input (only the EOF marker) reads as zero bytes, not an error.
+    #[test]
+    fn empty_stream_reads_nothing() {
+        let blob = make_bgzf(b"", 6);
+        assert!(read_mt(&blob, 4).is_empty());
+    }
+
+    /// Small `read` buffers must reassemble the stream correctly across block boundaries.
+    #[test]
+    fn tiny_reads_reassemble_stream() {
+        let input = sample(150_000);
+        let blob = make_bgzf(&input, 6);
+        let mut reader =
+            MultithreadedReader::with_worker_count(NonZero::new(4).unwrap(), owned(&blob));
+        let mut out = vec![];
+        let mut byte = [0u8; 1];
+        while reader.read(&mut byte).unwrap() == 1 {
+            out.push(byte[0]);
+        }
+        assert_eq!(out, input);
+    }
+
+    /// A stream truncated partway through a block must surface an error through `read`, the
+    /// same as the single-threaded reader (not be silently treated as EOF).
+    #[test]
+    fn truncated_block_errors() {
+        let input = sample(200_000);
+        let blob = make_bgzf(&input, 6);
+        // Cut inside the final data block (after the EOF-free portion): drop the trailing
+        // EOF marker and part of the last block.
+        let truncated = &blob[..blob.len() - crate::BGZF_EOF.len() - 20];
+
+        let mut reader =
+            MultithreadedReader::with_worker_count(NonZero::new(4).unwrap(), owned(truncated));
+        let mut out = vec![];
+        assert!(
+            reader.read_to_end(&mut out).is_err(),
+            "a truncated trailing block must error, not read as EOF"
+        );
+    }
+
+    /// A corrupt block header must surface as an error.
+    #[test]
+    fn corrupt_header_errors() {
+        let input = sample(120_000);
+        let mut blob = make_bgzf(&input, 6);
+        // Clobber the BC subfield identifier in the first block's header.
+        blob[12] = b'X';
+
+        let mut reader =
+            MultithreadedReader::with_worker_count(NonZero::new(2).unwrap(), owned(&blob));
+        let mut out = vec![];
+        assert!(reader.read_to_end(&mut out).is_err());
+    }
+
+    /// A corrupt block payload (bad CRC) must be rejected — CRC is verified in the workers.
+    #[test]
+    fn corrupt_payload_errors() {
+        let input = sample(80_000);
+        let mut blob = make_bgzf(&input, 6);
+        // Flip a byte inside the first block's compressed payload.
+        blob[BGZF_HEADER_SIZE + 2] ^= 0xff;
+
+        let mut reader =
+            MultithreadedReader::with_worker_count(NonZero::new(4).unwrap(), owned(&blob));
+        let mut out = vec![];
+        assert!(reader.read_to_end(&mut out).is_err());
+    }
+
+    /// Dropping the reader mid-stream (without consuming everything) must not deadlock or
+    /// leak threads — the pipeline shuts down cleanly.
+    #[test]
+    fn early_drop_is_clean() {
+        let input = sample(500_000); // many blocks so plenty remain unread
+        let blob = make_bgzf(&input, 6);
+        let mut reader =
+            MultithreadedReader::with_worker_count(NonZero::new(4).unwrap(), owned(&blob));
+        let mut small = [0u8; 64];
+        let _ = reader.read(&mut small).unwrap();
+        drop(reader); // must return promptly
+    }
+
+    /// `finish` returns the inner reader and joins cleanly.
+    #[test]
+    fn finish_returns_inner() {
+        let input = sample(100_000);
+        let blob = make_bgzf(&input, 6);
+        let mut reader = MultithreadedReader::new(owned(&blob));
+        let mut out = vec![];
+        reader.read_to_end(&mut out).unwrap();
+        assert_eq!(out, input);
+        reader.finish().expect("finish should join cleanly");
+    }
+
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(48))]
+
+        /// For arbitrary input, level, and worker count, the multithreaded reader must agree
+        /// with the single-threaded reader (and with the original input).
+        #[test]
+        fn proptest_mt_reader_matches_serial(
+            input in prop::collection::vec(any::<u8>(), 1..100_000usize),
+            comp_level in 0..=12u8,
+            workers in 1usize..=4,
+        ) {
+            let blob = make_bgzf(&input, comp_level);
+
+            let mut serial = vec![];
+            Reader::new(blob.as_slice()).read_to_end(&mut serial).unwrap();
+            prop_assert_eq!(&serial, &input);
+
+            let mut mt = vec![];
+            MultithreadedReader::with_worker_count(NonZero::new(workers).unwrap(), owned(&blob))
+                .read_to_end(&mut mt)
+                .unwrap();
+            prop_assert_eq!(mt, input);
+        }
+    }
+}

--- a/src/multithreaded_reader.rs
+++ b/src/multithreaded_reader.rs
@@ -49,6 +49,24 @@ use crate::{
 /// `worker_count.max(MIN_BUFFERS)` so even a single-worker reader reads ahead.
 const MIN_BUFFERS: usize = 8;
 
+// Channel type aliases. The unit of work moved across them is a [`Buffer`] (defined below).
+//
+// A per-block "one-shot": the worker sends the decoded (or failed) buffer back on it, and the
+// consumer — holding the matching receiver, pulled in file order — waits on it. A purpose-built
+// single-message `oneshot` channel is cheaper here than a general MPMC `bounded(1)`.
+type Decoded = io::Result<Buffer>;
+type DecodedTx = oneshot::Sender<Decoded>;
+type DecodedRx = oneshot::Receiver<Decoded>;
+// Reader → workers: a raw block plus the one-shot to answer on.
+type InflateTx = Sender<(Buffer, DecodedTx)>;
+type InflateRx = Receiver<(Buffer, DecodedTx)>;
+// Reader → consumer: the one-shot receivers, in file order.
+type OrderTx = Sender<DecodedRx>;
+type OrderRx = Receiver<DecodedRx>;
+// Consumer → reader: spent buffers to reuse.
+type RecycleTx = Sender<Buffer>;
+type RecycleRx = Receiver<Buffer>;
+
 /// A recycled unit of work that cycles reader → worker → consumer → reader with no per-block
 /// allocation.
 ///
@@ -72,22 +90,6 @@ struct Buffer {
     pos: usize,
 }
 
-// A per-block "one-shot": the worker sends the decoded (or failed) buffer back on it, and the
-// consumer — holding the matching receiver, pulled in file order — waits on it. A purpose-built
-// single-message `oneshot` channel is cheaper here than a general MPMC `bounded(1)`.
-type Decoded = io::Result<Buffer>;
-type DecodedTx = oneshot::Sender<Decoded>;
-type DecodedRx = oneshot::Receiver<Decoded>;
-// Reader → workers: a raw block plus the one-shot to answer on.
-type InflateTx = Sender<(Buffer, DecodedTx)>;
-type InflateRx = Receiver<(Buffer, DecodedTx)>;
-// Reader → consumer: the one-shot receivers, in file order.
-type OrderTx = Sender<DecodedRx>;
-type OrderRx = Receiver<DecodedRx>;
-// Consumer → reader: spent buffers to reuse.
-type RecycleTx = Sender<Buffer>;
-type RecycleRx = Receiver<Buffer>;
-
 enum State<R> {
     Running {
         reader_handle: JoinHandle<R>,
@@ -101,7 +103,7 @@ enum State<R> {
 /// A multithreaded BGZF reader.
 ///
 /// Decompresses blocks on a dedicated pool of worker threads while exposing a sequential
-/// [`Read`]/[`BufRead`] interface. See the [module docs](self) for the design.
+/// [`Read`]/[`BufRead`] interface. See the module-level documentation for the design.
 ///
 /// The worker threads are joined when the reader is dropped; call [`finish`](Self::finish)
 /// instead if you need to observe reader-thread panics or reclaim the inner reader.
@@ -140,7 +142,7 @@ where
     /// Create a reader with the given number of inflater worker threads.
     ///
     /// The read-ahead depth is `worker_count.max(8)` regardless of `worker_count`, so a
-    /// single-worker reader still reads ahead (see the [module docs](self)).
+    /// single-worker reader still reads ahead (see the module-level documentation).
     pub fn with_worker_count(worker_count: NonZero<usize>, inner: R) -> Self {
         let capacity = worker_count.get().max(MIN_BUFFERS);
 
@@ -221,6 +223,13 @@ where
     }
 }
 
+impl MultithreadedReader<std::fs::File> {
+    /// Create a multithreaded reader over a file at `path`.
+    pub fn from_path<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+        std::fs::File::open(path).map(Self::new)
+    }
+}
+
 impl<R> Read for MultithreadedReader<R>
 where
     R: Read + Send + 'static,
@@ -265,13 +274,6 @@ where
         if matches!(self.state, State::Running { .. }) {
             let _ = self.finish();
         }
-    }
-}
-
-impl MultithreadedReader<std::fs::File> {
-    /// Create a multithreaded reader over a file at `path`.
-    pub fn from_path<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
-        std::fs::File::open(path).map(Self::new)
     }
 }
 

--- a/src/multithreaded_reader.rs
+++ b/src/multithreaded_reader.rs
@@ -8,7 +8,7 @@
 //!
 //! # Design
 //!
-//! Three roles connected by [`kanal`] channels, modelled on noodles-bgzf's
+//! Three roles connected by `crossbeam-channel` channels, modelled on noodles-bgzf's
 //! `MultithreadedReader` but using this crate's block internals:
 //!
 //! - **Reader thread** — reads raw blocks (header + payload + footer) in file order,
@@ -35,7 +35,7 @@ use std::io::{self, BufRead, Read};
 use std::num::NonZero;
 use std::thread::{self, JoinHandle};
 
-use kanal::{bounded, Receiver, Sender};
+use crossbeam_channel::{bounded, Receiver, Sender};
 
 use crate::reader::read_full;
 use crate::{

--- a/src/multithreaded_writer.rs
+++ b/src/multithreaded_writer.rs
@@ -1,0 +1,504 @@
+//! A per-instance multithreaded BGZF writer.
+//!
+//! [`MultithreadedWriter`] compresses BGZF blocks on a pool of worker threads it owns,
+//! while presenting a plain [`std::io::Write`] to the caller. It is a drop-in,
+//! higher-throughput alternative to the single-threaded [`Writer`](crate::Writer) for large
+//! streams; its output is a valid BGZF stream decodable by any BGZF reader.
+//!
+//! # Design
+//!
+//! The mirror image of [`MultithreadedReader`](crate::MultithreadedReader), modelled on
+//! noodles-bgzf's `MultithreadedWriter`:
+//!
+//! - **Caller** (the `Write` impl) — accumulates bytes into a staging buffer and, each time a
+//!   block fills, hands it to the worker pool while registering its slot with the writer
+//!   thread so output order is preserved.
+//! - **Deflater workers** — compress blocks in parallel using this crate's
+//!   [`Compressor`](crate::Compressor) (so compression level 0 emits stored blocks, exactly
+//!   like the single-threaded writer).
+//! - **Writer thread** — pulls compressed blocks *in submission order*, writes them to the
+//!   inner writer, and appends the BGZF EOF marker on shutdown.
+//!
+//! Block ordering falls out of a FIFO of per-block one-shot channels: the caller pushes each
+//! block's result-receiver onto the writer thread's queue in order, and the writer thread
+//! drains them in that order, blocking on each until its worker finishes. Workers may finish
+//! out of order; the output never does.
+//!
+//! As with the reader, the channels are sized to `worker_count.max(MIN_BUFFERS)` so a
+//! single-worker writer still has blocks in flight rather than stalling on a synchronous
+//! per-block handoff.
+
+use std::io::{self, Write};
+use std::num::NonZero;
+use std::thread::{self, JoinHandle};
+
+use bytes::{Bytes, BytesMut};
+use kanal::{bounded, Receiver, Sender};
+
+use crate::{BgzfError, CompressionLevel, Compressor, BGZF_BLOCK_SIZE, BGZF_EOF};
+
+/// Write-ahead depth floor; see [`MultithreadedReader`](crate::MultithreadedReader)'s
+/// `MIN_BUFFERS` for the rationale (a single-worker writer must still pipeline).
+const MIN_BUFFERS: usize = 8;
+
+// A per-block "one-shot": a worker sends the framed, compressed block (or a compression
+// error) back on it, and the writer thread — holding the matching receiver, pulled in
+// submission order — waits on it.
+type Compressed = io::Result<Vec<u8>>;
+type CompressedTx = Sender<Compressed>;
+type CompressedRx = Receiver<Compressed>;
+// Caller → workers: the uncompressed block plus the one-shot to answer on.
+type DeflateTx = Sender<(Bytes, CompressedTx)>;
+type DeflateRx = Receiver<(Bytes, CompressedTx)>;
+// Caller → writer thread: the one-shot receivers, in submission order.
+type OrderTx = Sender<CompressedRx>;
+type OrderRx = Receiver<CompressedRx>;
+
+enum State<W> {
+    Running {
+        writer_handle: JoinHandle<io::Result<W>>,
+        deflater_handles: Vec<JoinHandle<()>>,
+        deflate_tx: DeflateTx,
+        order_tx: OrderTx,
+    },
+    Done,
+}
+
+/// A multithreaded BGZF writer.
+///
+/// Compresses blocks on a dedicated pool of worker threads while writing them, in order, to
+/// the inner writer. See the [module docs](self) for the design.
+///
+/// # Finishing
+///
+/// Like the single-threaded [`Writer`](crate::Writer), you should call
+/// [`finish`](Self::finish) when done: it flushes buffered data, drains the worker pool,
+/// writes the BGZF EOF marker, and surfaces any compression or I/O error. If the writer is
+/// dropped instead, finishing still happens but errors are silently ignored.
+///
+/// # Example
+///
+/// ```rust
+/// # #[cfg(feature = "multithreading-simple")] {
+/// use std::io::Write;
+/// use bgzf::{CompressionLevel, MultithreadedWriter};
+/// let mut writer = MultithreadedWriter::new(vec![], CompressionLevel::new(6).unwrap());
+/// writer.write_all(b"hello world").unwrap();
+/// let compressed = writer.finish().unwrap();
+/// # }
+/// ```
+pub struct MultithreadedWriter<W>
+where
+    W: Write + Send + 'static,
+{
+    state: State<W>,
+    /// Staging buffer of not-yet-dispatched uncompressed bytes for the current block.
+    buf: BytesMut,
+    /// Uncompressed bytes per block.
+    blocksize: usize,
+}
+
+impl<W> MultithreadedWriter<W>
+where
+    W: Write + Send + 'static,
+{
+    /// Create a writer with a worker count derived from the available parallelism.
+    pub fn new(inner: W, compression_level: CompressionLevel) -> Self {
+        let workers = thread::available_parallelism().map_or(1, NonZero::get);
+        Self::with_worker_count(
+            NonZero::new(workers).unwrap_or(NonZero::<usize>::MIN),
+            inner,
+            compression_level,
+        )
+    }
+
+    /// Create a writer with the given number of deflater worker threads.
+    pub fn with_worker_count(
+        worker_count: NonZero<usize>,
+        inner: W,
+        compression_level: CompressionLevel,
+    ) -> Self {
+        Self::with_capacity(worker_count, inner, compression_level, BGZF_BLOCK_SIZE)
+    }
+
+    /// Create a writer with the given worker count and uncompressed block size.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `blocksize` is not in `1..=BGZF_BLOCK_SIZE`.
+    pub fn with_capacity(
+        worker_count: NonZero<usize>,
+        inner: W,
+        compression_level: CompressionLevel,
+        blocksize: usize,
+    ) -> Self {
+        assert!(
+            (1..=BGZF_BLOCK_SIZE).contains(&blocksize),
+            "blocksize must be in 1..={BGZF_BLOCK_SIZE}"
+        );
+        let capacity = worker_count.get().max(MIN_BUFFERS);
+
+        let (deflate_tx, deflate_rx) = bounded::<(Bytes, CompressedTx)>(capacity);
+        let (order_tx, order_rx) = bounded::<CompressedRx>(capacity);
+
+        let deflater_handles = spawn_deflaters(compression_level, worker_count.get(), deflate_rx);
+        let writer_handle = spawn_writer(inner, order_rx);
+
+        Self {
+            state: State::Running { writer_handle, deflater_handles, deflate_tx, order_tx },
+            buf: BytesMut::with_capacity(blocksize),
+            blocksize,
+        }
+    }
+
+    /// Flush buffered data, drain the worker pool, write the BGZF EOF marker, and return the
+    /// inner writer.
+    ///
+    /// Prefer this over dropping the writer: it surfaces compression and I/O errors that the
+    /// `Drop` path would silently swallow, and guarantees the EOF marker is written exactly
+    /// once.
+    pub fn finish(&mut self) -> io::Result<W> {
+        if !self.buf.is_empty() {
+            self.send()?;
+        }
+        match std::mem::replace(&mut self.state, State::Done) {
+            State::Running { writer_handle, mut deflater_handles, deflate_tx, order_tx } => {
+                // Close the deflater input so workers finish once they have drained it, then
+                // join them. Closing the order channel afterwards lets the writer thread
+                // drain its queue, append EOF, and return the inner writer.
+                drop(deflate_tx);
+                for handle in deflater_handles.drain(..) {
+                    handle.join().map_err(|_| thread_panicked("deflater"))?;
+                }
+                drop(order_tx);
+                writer_handle.join().map_err(|_| thread_panicked("writer"))?
+            }
+            State::Done => Err(io::Error::new(io::ErrorKind::Other, "writer already finished")),
+        }
+    }
+
+    /// Dispatch the staging buffer to the worker pool as one block, preserving order.
+    fn send(&mut self) -> io::Result<()> {
+        if self.buf.is_empty() {
+            return Ok(());
+        }
+        let State::Running { deflate_tx, order_tx, .. } = &self.state else {
+            return Err(io::Error::new(io::ErrorKind::Other, "writer already finished"));
+        };
+
+        let data = self.buf.split().freeze();
+        let (compressed_tx, compressed_rx) = bounded::<Compressed>(1);
+        deflate_tx
+            .send((data, compressed_tx))
+            .map_err(|_| io::Error::new(io::ErrorKind::Other, "bgzf writer pipeline stopped"))?;
+        order_tx
+            .send(compressed_rx)
+            .map_err(|_| io::Error::new(io::ErrorKind::Other, "bgzf writer pipeline stopped"))?;
+        Ok(())
+    }
+}
+
+impl<W> Write for MultithreadedWriter<W>
+where
+    W: Write + Send + 'static,
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let n = (self.blocksize - self.buf.len()).min(buf.len());
+        self.buf.extend_from_slice(&buf[..n]);
+        if self.buf.len() >= self.blocksize {
+            self.send()?;
+        }
+        Ok(n)
+    }
+
+    /// Dispatch any buffered data as a block. Note this does not wait for that block to reach
+    /// the inner writer, nor flush the inner writer (which the writer thread owns) — call
+    /// [`finish`](Self::finish) to fully drain the pipeline.
+    fn flush(&mut self) -> io::Result<()> {
+        self.send()
+    }
+}
+
+impl<W> Drop for MultithreadedWriter<W>
+where
+    W: Write + Send + 'static,
+{
+    fn drop(&mut self) {
+        if matches!(self.state, State::Running { .. }) {
+            let _ = self.finish();
+        }
+    }
+}
+
+impl MultithreadedWriter<std::fs::File> {
+    /// Create a multithreaded writer over a new file at `path`.
+    pub fn from_path<P: AsRef<std::path::Path>>(
+        path: P,
+        compression_level: CompressionLevel,
+    ) -> io::Result<Self> {
+        std::fs::File::create(path).map(|f| Self::new(f, compression_level))
+    }
+}
+
+fn thread_panicked(which: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, format!("bgzf {which} thread panicked"))
+}
+
+/// The deflater workers: compress each block and answer its one-shot with the framed bytes.
+fn spawn_deflaters(
+    compression_level: CompressionLevel,
+    worker_count: usize,
+    deflate_rx: DeflateRx,
+) -> Vec<JoinHandle<()>> {
+    (0..worker_count)
+        .map(|_| {
+            let deflate_rx = deflate_rx.clone();
+            thread::spawn(move || {
+                let mut compressor = Compressor::new(compression_level);
+                while let Ok((data, compressed_tx)) = deflate_rx.recv() {
+                    // v1 allocates one output buffer per block; recycling is a future,
+                    // bench-gated optimization (see CHANGELOG).
+                    let mut out = Vec::new();
+                    let result = compressor.compress(&data, &mut out).map(|()| out).map_err(to_io);
+                    compressed_tx.send(result).ok();
+                }
+            })
+        })
+        .collect()
+}
+
+/// The writer thread: write compressed blocks in submission order, then append EOF.
+fn spawn_writer<W>(mut writer: W, order_rx: OrderRx) -> JoinHandle<io::Result<W>>
+where
+    W: Write + Send + 'static,
+{
+    thread::spawn(move || {
+        while let Ok(compressed_rx) = order_rx.recv() {
+            let block = compressed_rx.recv().map_err(|_| {
+                io::Error::new(io::ErrorKind::Other, "bgzf deflater thread stopped")
+            })??;
+            writer.write_all(&block)?;
+        }
+        writer.write_all(BGZF_EOF)?;
+        writer.flush()?;
+        Ok(writer)
+    })
+}
+
+fn to_io(e: BgzfError) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, e)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+    use std::sync::{Arc, Mutex};
+
+    use crate::{CompressionLevel, Reader};
+
+    use super::*;
+
+    fn level(n: u8) -> CompressionLevel {
+        CompressionLevel::new(n).unwrap()
+    }
+
+    /// A deterministic, multi-block payload.
+    fn sample(len: usize) -> Vec<u8> {
+        (0..len as u32).map(|i| i.wrapping_mul(2_654_435_761).rotate_left(13) as u8).collect()
+    }
+
+    /// An owned, `'static + Send` sink whose bytes remain inspectable after the writer that
+    /// held it is dropped — needed to test the `Drop` path (which discards the inner writer).
+    #[derive(Clone)]
+    struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+    impl SharedBuf {
+        fn new() -> Self {
+            Self(Arc::new(Mutex::new(vec![])))
+        }
+        fn bytes(&self) -> Vec<u8> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    impl Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn decode(blob: &[u8]) -> Vec<u8> {
+        let mut out = vec![];
+        Reader::new(blob).read_to_end(&mut out).unwrap();
+        out
+    }
+
+    /// Compress `input` with the multithreaded writer, reclaiming the framed blob via `finish`.
+    fn write_mt(input: &[u8], workers: usize, comp_level: u8) -> Vec<u8> {
+        let mut writer = MultithreadedWriter::with_worker_count(
+            NonZero::new(workers).unwrap(),
+            Vec::new(),
+            level(comp_level),
+        );
+        writer.write_all(input).unwrap();
+        writer.finish().unwrap()
+    }
+
+    /// The multithreaded writer's output must round-trip through the single-threaded reader,
+    /// at every worker count and compression level, for multi-block input.
+    #[test]
+    fn round_trips_through_serial_reader() {
+        let input = sample(300_000);
+        for comp_level in [0u8, 1, 6] {
+            for workers in [1usize, 2, 4, 8] {
+                assert_eq!(
+                    decode(&write_mt(&input, workers, comp_level)),
+                    input,
+                    "mt writer diverged at level {comp_level}, {workers} workers"
+                );
+            }
+        }
+    }
+
+    /// Output must be independent of how writes are chunked across block boundaries.
+    #[test]
+    fn output_independent_of_write_chunking() {
+        let input = sample(200_000);
+
+        let one_shot = write_mt(&input, 4, 6);
+
+        let chunked = {
+            let mut w = MultithreadedWriter::with_worker_count(
+                NonZero::new(4).unwrap(),
+                Vec::new(),
+                level(6),
+            );
+            for chunk in input.chunks(7) {
+                w.write_all(chunk).unwrap();
+            }
+            w.finish().unwrap()
+        };
+
+        // Block boundaries depend only on block size, so the framing must be identical
+        // regardless of write chunking.
+        assert_eq!(one_shot, chunked);
+    }
+
+    /// Writing nothing must still produce exactly the EOF marker.
+    #[test]
+    fn empty_writes_only_eof() {
+        let out = MultithreadedWriter::new(Vec::new(), level(6)).finish().unwrap();
+        assert_eq!(out.as_slice(), BGZF_EOF);
+    }
+
+    /// The EOF marker must appear exactly once, whether finishing explicitly or via drop.
+    #[test]
+    fn eof_written_once() {
+        for use_finish in [true, false] {
+            let sink = SharedBuf::new();
+            {
+                let mut w = MultithreadedWriter::with_worker_count(
+                    NonZero::new(3).unwrap(),
+                    sink.clone(),
+                    level(6),
+                );
+                w.write_all(b"some data to compress").unwrap();
+                if use_finish {
+                    w.finish().unwrap();
+                }
+            }
+            let out = sink.bytes();
+            assert!(
+                out.ends_with(BGZF_EOF),
+                "output must end with the EOF marker (finish={use_finish})"
+            );
+            let eof_count = out.windows(BGZF_EOF.len()).filter(|w| *w == BGZF_EOF).count();
+            assert_eq!(eof_count, 1, "EOF marker should appear exactly once (finish={use_finish})");
+        }
+    }
+
+    /// Level 0 through the multithreaded writer must produce store-only output that the
+    /// reader round-trips (exercises the stored-block path end to end).
+    #[test]
+    fn level_zero_round_trips() {
+        let input = sample(250_000);
+        assert_eq!(decode(&write_mt(&input, 4, 0)), input);
+    }
+
+    /// The multithreaded writer splits blocks at the same boundaries and compresses each with
+    /// the same `Compressor` as the single-threaded [`Writer`](crate::Writer), so for the same
+    /// input its framed output must be byte-for-byte identical — at every level including 0.
+    #[test]
+    fn matches_single_threaded_writer_byte_for_byte() {
+        use crate::Writer;
+
+        let input = sample(200_000);
+        for comp_level in [0u8, 1, 6, 9] {
+            let serial = {
+                let mut out = vec![];
+                let mut w = Writer::new(&mut out, level(comp_level));
+                w.write_all(&input).unwrap();
+                w.finish().unwrap();
+                out
+            };
+            let mt = write_mt(&input, 4, comp_level);
+            assert_eq!(mt, serial, "mt vs serial writer framing differs at level {comp_level}");
+        }
+    }
+
+    /// End-to-end through both multithreaded halves.
+    #[test]
+    fn mt_writer_to_mt_reader_round_trips() {
+        use std::io::Cursor;
+
+        use crate::MultithreadedReader;
+
+        let input = sample(400_000);
+        for comp_level in [0u8, 6] {
+            let compressed = write_mt(&input, 4, comp_level);
+            let mut out = vec![];
+            MultithreadedReader::with_worker_count(
+                NonZero::new(3).unwrap(),
+                Cursor::new(compressed),
+            )
+            .read_to_end(&mut out)
+            .unwrap();
+            assert_eq!(out, input, "mt->mt round trip failed at level {comp_level}");
+        }
+    }
+
+    /// `flush()` mid-stream forces a block boundary but must not corrupt the stream.
+    #[test]
+    fn flush_midstream_round_trips() {
+        let input = sample(100_000);
+        let mut w =
+            MultithreadedWriter::with_worker_count(NonZero::new(4).unwrap(), Vec::new(), level(6));
+        w.write_all(&input[..40_000]).unwrap();
+        w.flush().unwrap();
+        w.write_all(&input[40_000..]).unwrap();
+        let compressed = w.finish().unwrap();
+        assert_eq!(decode(&compressed), input);
+    }
+
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(48))]
+
+        /// For arbitrary input, level, and worker count, the multithreaded writer's output must
+        /// round-trip through the single-threaded reader.
+        #[test]
+        fn proptest_mt_writer_round_trips(
+            input in prop::collection::vec(any::<u8>(), 1..100_000usize),
+            comp_level in 0..=12u8,
+            workers in 1usize..=4,
+        ) {
+            let blob = write_mt(&input, workers, comp_level);
+            prop_assert_eq!(decode(&blob), input);
+        }
+    }
+}

--- a/src/multithreaded_writer.rs
+++ b/src/multithreaded_writer.rs
@@ -33,7 +33,7 @@ use std::num::NonZero;
 use std::thread::{self, JoinHandle};
 
 use bytes::{Bytes, BytesMut};
-use kanal::{bounded, Receiver, Sender};
+use crossbeam_channel::{bounded, Receiver, Sender};
 
 use crate::{BgzfError, CompressionLevel, Compressor, BGZF_BLOCK_SIZE, BGZF_EOF};
 

--- a/src/multithreaded_writer.rs
+++ b/src/multithreaded_writer.rs
@@ -68,7 +68,7 @@ enum State<W> {
 /// A multithreaded BGZF writer.
 ///
 /// Compresses blocks on a dedicated pool of worker threads while writing them, in order, to
-/// the inner writer. See the [module docs](self) for the design.
+/// the inner writer. See the module-level documentation for the design.
 ///
 /// # Finishing
 ///
@@ -199,6 +199,16 @@ where
     }
 }
 
+impl MultithreadedWriter<std::fs::File> {
+    /// Create a multithreaded writer over a new file at `path`.
+    pub fn from_path<P: AsRef<std::path::Path>>(
+        path: P,
+        compression_level: CompressionLevel,
+    ) -> io::Result<Self> {
+        std::fs::File::create(path).map(|f| Self::new(f, compression_level))
+    }
+}
+
 impl<W> Write for MultithreadedWriter<W>
 where
     W: Write + Send + 'static,
@@ -228,16 +238,6 @@ where
         if matches!(self.state, State::Running { .. }) {
             let _ = self.finish();
         }
-    }
-}
-
-impl MultithreadedWriter<std::fs::File> {
-    /// Create a multithreaded writer over a new file at `path`.
-    pub fn from_path<P: AsRef<std::path::Path>>(
-        path: P,
-        compression_level: CompressionLevel,
-    ) -> io::Result<Self> {
-        std::fs::File::create(path).map(|f| Self::new(f, compression_level))
     }
 }
 

--- a/src/multithreaded_writer.rs
+++ b/src/multithreaded_writer.rs
@@ -41,12 +41,13 @@ use crate::{BgzfError, CompressionLevel, Compressor, BGZF_BLOCK_SIZE, BGZF_EOF};
 /// `MIN_BUFFERS` for the rationale (a single-worker writer must still pipeline).
 const MIN_BUFFERS: usize = 8;
 
-// A per-block "one-shot": a worker sends the framed, compressed block (or a compression
-// error) back on it, and the writer thread — holding the matching receiver, pulled in
-// submission order — waits on it.
+// A per-block "one-shot": a worker sends the framed, compressed block (or a compression error)
+// back on it, and the writer thread — holding the matching receiver, pulled in submission order —
+// waits on it. A purpose-built single-message `oneshot` channel is cheaper here than a general
+// MPMC `bounded(1)`.
 type Compressed = io::Result<Vec<u8>>;
-type CompressedTx = Sender<Compressed>;
-type CompressedRx = Receiver<Compressed>;
+type CompressedTx = oneshot::Sender<Compressed>;
+type CompressedRx = oneshot::Receiver<Compressed>;
 // Caller → workers: the uncompressed block plus the one-shot to answer on.
 type DeflateTx = Sender<(Bytes, CompressedTx)>;
 type DeflateRx = Receiver<(Bytes, CompressedTx)>;
@@ -187,7 +188,7 @@ where
         };
 
         let data = self.buf.split().freeze();
-        let (compressed_tx, compressed_rx) = bounded::<Compressed>(1);
+        let (compressed_tx, compressed_rx) = oneshot::channel::<Compressed>();
         deflate_tx
             .send((data, compressed_tx))
             .map_err(|_| io::Error::new(io::ErrorKind::Other, "bgzf writer pipeline stopped"))?;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -252,7 +252,7 @@ where
 /// Returns `Ok(true)` once `buf` is full, `Ok(false)` if the stream ends cleanly before any byte is
 /// read (a normal end-of-stream at a block boundary), and an error if the stream ends partway
 /// through (a truncated block) or the underlying read fails.
-fn read_full<R: Read>(reader: &mut R, buf: &mut [u8]) -> io::Result<bool> {
+pub(crate) fn read_full<R: Read>(reader: &mut R, buf: &mut [u8]) -> io::Result<bool> {
     let mut filled = 0;
     while filled < buf.len() {
         match reader.read(&mut buf[filled..]) {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -71,7 +71,8 @@ where
 
     /// Create a writer with a set capacity.
     ///
-    /// By default the capacity is [`bgzf::BUFSIZE`]. The capacity must be less than or equal to [`bgzf::BGZF_BLOCK_SIZE`].
+    /// By default (via [`Writer::new`]) the block size is [`crate::BGZF_BLOCK_SIZE`], which is
+    /// also the maximum permitted; `blocksize` must be less than or equal to it.
     pub fn with_capacity(writer: W, compression_level: CompressionLevel, blocksize: usize) -> Self {
         // A zero block size would loop forever while emitting blocks.
         assert!(


### PR DESCRIPTION
## Summary

Opt-in per-instance multithreaded BGZF reader/writer behind the new `multithreading-simple`
feature (default build unchanged). `MultithreadedReader` and `MultithreadedWriter` each own a
dedicated pool of worker threads that (de)compress blocks in parallel while preserving block
order, exposing the same `std::io::Read`/`Write` (and `BufRead`) interfaces as the
single-threaded types. Decompressed output is byte-identical to `Reader`, and compressed output
byte-identical to `Writer`, at every worker count. Adds optional deps `crossbeam-channel` (pool
queues) and `oneshot` (per-block result handoff). Intended as a drop-in for noodles' multithreaded
reader. Read-ahead/write-ahead depth is decoupled from worker count (`worker_count.max(8)`) so a
single-worker instance still pipelines.

## Real vs. mechanical changes

**Feature — all new files:**
- `src/multithreaded_reader.rs`, `src/multithreaded_writer.rs` — the two types, tests, proptests.
- `benches/multithreaded.rs` — single-threaded vs 1/2/4-worker benches.

**Wiring & docs (real):** `Cargo.toml`, `src/lib.rs`, `README.md`, `CHANGELOG.md`, and CI
(`--all-features` tests + a `cargo doc -D warnings` check).

**Touches to single-threaded code — trivial, _not_ feature logic:**
- `src/reader.rs` — **1 line**: `read_full` made `pub(crate)` so the MT reader reuses it.
- `src/writer.rs` — **doc-only**: fixed a pre-existing broken + self-contradictory doc on
  `Writer::with_capacity` (it claimed the default block size was `BUFSIZE`, which is larger than
  the stated maximum). No behavior change.

**Pure reordering/reformatting (no behavior change):** the final commit (`c8d0e22`) regroups the
channel type aliases and moves the `from_path` impls within the two new MT files to match house
module-ordering conventions.

## Commits

- `f2f84ec` — feat: the reader + writer (the feature).
- `de1e900` / `d8e9572` / `aa409ad` — perf tuning, in order: kanal→crossbeam channels, removing
  per-block buffer zero-fills, and a purpose-built `oneshot` for the per-block handoff. See the
  commit messages for the rationale (each was driven by a measured regression/gap).
- `c8d0e22` — docs + conventions polish (mostly docs; the code moves are cosmetic).

## Notes

- The multithreading tests require `--all-features`. Full gate is green: fmt, clippy
  (default + `--all-features`), `cargo doc -D warnings`, and tests in both configs.
- The writer allocates one output buffer per block for now; compressed-buffer recycling is a
  planned, benchmark-gated follow-up (noted in the CHANGELOG).