### PR TITLE
feat(reader): implement std::io::BufRead for Reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `Reader` now implements `std::io::BufRead` (matching `MultithreadedReader`), enabling
+  `read_until`, `lines`, etc., and letting callers borrow the decompressed block buffer directly
+  instead of wrapping the reader in a `BufReader` (which would redundantly re-buffer already
+  decompressed bytes).
+
 ## [0.4.0] - 2026-07-04
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,7 +479,7 @@ fn stored_block_len(deflate_header: &[u8]) -> Option<usize> {
 
 #[cfg(test)]
 mod test {
-    use std::io::{Read, Write};
+    use std::io::{BufRead, Read, Write};
     use std::{
         fs::File,
         io::{BufReader, BufWriter},
@@ -950,6 +950,72 @@ mod test {
         let mut decoded = vec![];
         Reader::new(blob.as_slice()).read_to_end(&mut decoded).unwrap();
         assert_eq!(decoded, input);
+    }
+
+    /// The reader implements [`BufRead`]: `lines()` yields the original lines (borrowing the
+    /// decompressed buffer rather than needing a wrapping `BufReader`).
+    #[test]
+    fn reader_bufread_lines_yields_original_lines() {
+        let text = "first line\nsecond line\nthird\n";
+        let mut blob = vec![];
+        let mut writer = Writer::new(&mut blob, CompressionLevel::new(6).unwrap());
+        writer.write_all(text.as_bytes()).unwrap();
+        writer.finish().unwrap();
+
+        let lines: Vec<String> =
+            Reader::new(blob.as_slice()).lines().collect::<std::io::Result<_>>().unwrap();
+        assert_eq!(lines, ["first line", "second line", "third"]);
+    }
+
+    /// `read_until` reads up to and including the delimiter, then the remainder streams normally.
+    #[test]
+    fn reader_bufread_read_until_delimiter() {
+        let mut blob = vec![];
+        let mut writer = Writer::new(&mut blob, CompressionLevel::new(3).unwrap());
+        writer.write_all(b"header\0payload bytes").unwrap();
+        writer.finish().unwrap();
+
+        let mut reader = Reader::new(blob.as_slice());
+        let mut first = vec![];
+        reader.read_until(0, &mut first).unwrap();
+        assert_eq!(first, b"header\0");
+        let mut rest = vec![];
+        reader.read_to_end(&mut rest).unwrap();
+        assert_eq!(rest, b"payload bytes");
+    }
+
+    /// Driving the reader purely through `fill_buf`/`consume` must reassemble a multi-block stream
+    /// byte-for-byte, transparently skipping empty blocks (the EOF marker) and ending on an empty
+    /// slice.
+    #[test]
+    fn reader_bufread_fill_buf_consume_across_blocks() {
+        let input: Vec<u8> = (0..200_000u32).map(|i| (i % 251) as u8).collect(); // spans blocks
+        let mut blob = vec![];
+        let mut writer = Writer::new(&mut blob, CompressionLevel::new(0).unwrap()); // store-only
+        writer.write_all(&input).unwrap();
+        writer.finish().unwrap();
+
+        let mut reader = Reader::new(blob.as_slice());
+        let mut out = vec![];
+        loop {
+            let chunk = reader.fill_buf().unwrap();
+            if chunk.is_empty() {
+                break; // end of input
+            }
+            // Consume in small pieces to exercise partial consumption within a block.
+            let take = chunk.len().min(7);
+            out.extend_from_slice(&chunk[..take]);
+            reader.consume(take);
+        }
+        assert_eq!(out, input);
+    }
+
+    /// `fill_buf` on an empty stream (only the EOF marker) returns an empty slice, not an error.
+    #[test]
+    fn reader_bufread_empty_stream_fills_empty() {
+        let mut blob = vec![];
+        Writer::new(&mut blob, CompressionLevel::new(6).unwrap()).finish().unwrap();
+        assert!(Reader::new(blob.as_slice()).fill_buf().unwrap().is_empty());
     }
 
     const DICT_SIZE: usize = 32768;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,7 +1,7 @@
 //! A Reader for BGZF compressed data.
 use std::{
     fs::File,
-    io::{self, Read},
+    io::{self, BufRead, Read},
     path::Path,
 };
 
@@ -104,6 +104,107 @@ where
         self.validate_crc = validate;
         self
     }
+
+    /// Read and decode the next BGZF block into `decompressed_buffer`, setting `block_pos`/
+    /// `block_end` to its bounds.
+    ///
+    /// Returns `Ok(true)` when a block was read (possibly an *empty* block, e.g. the EOF marker),
+    /// `Ok(false)` on a clean end of stream at a block boundary, and an error for a truncated or
+    /// malformed block. Assumes the current block is already exhausted (`block_pos == block_end`).
+    fn fetch_next_block(&mut self) -> io::Result<bool> {
+        // Read the 18-byte BGZF header together with the 5-byte DEFLATE block header. Reading
+        // both at once lets us choose the stored fast path without a second read: a clean EOF
+        // at a block boundary stops the stream, while a partial read signals a truncated block.
+        if !read_full(&mut self.reader, &mut self.header_buffer)? {
+            return Ok(false); // clean EOF
+        }
+        check_header(&self.header_buffer[..BGZF_HEADER_SIZE])
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+        // A valid block always holds at least a header and footer; anything smaller is a
+        // corrupt header and would underflow `payload_len`.
+        let block_size = get_block_size(&self.header_buffer[..BGZF_HEADER_SIZE]);
+        if block_size < BGZF_HEADER_SIZE + BGZF_FOOTER_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                BgzfError::InvalidHeader("block size smaller than header plus footer"),
+            ));
+        }
+        let payload_len = block_size - BGZF_HEADER_SIZE;
+
+        // The 5 bytes after the BGZF header are the DEFLATE block header. Copy them out so we
+        // can both inspect them and, on the inflate path, prepend them to the payload.
+        let deflate_header: [u8; DEFLATE_STORED_HEADER_SIZE] = self.header_buffer
+            [BGZF_HEADER_SIZE..]
+            .try_into()
+            .expect("header_buffer holds the DEFLATE block header");
+
+        // Fast path: a single final stored block that spans the whole payload holds its bytes
+        // verbatim. Read the data and its footer straight into the decompressed buffer (at
+        // offset 0, so callers drain an aligned, contiguous slice), skipping libdeflate and any
+        // staging copy, then verify the uncompressed size and CRC.
+        if let Some(len) = stored_block_len(&deflate_header) {
+            let with_footer = len + BGZF_FOOTER_SIZE;
+            if payload_len == DEFLATE_STORED_HEADER_SIZE + with_footer
+                && with_footer <= self.decompressed_buffer.len()
+            {
+                self.reader.read_exact(&mut self.decompressed_buffer[..with_footer])?;
+                let check = get_footer_values(&self.decompressed_buffer[..with_footer]);
+                if check.amount as usize != len {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        BgzfError::InvalidHeader("stored block length disagrees with footer"),
+                    ));
+                }
+                if self.validate_crc {
+                    let found = crc32(&self.decompressed_buffer[..len]);
+                    if found != check.sum {
+                        return Err(io::Error::new(
+                            io::ErrorKind::Other,
+                            BgzfError::InvalidChecksum { found, expected: check.sum },
+                        ));
+                    }
+                }
+                self.block_pos = 0;
+                self.block_end = len;
+                return Ok(true);
+            }
+        }
+
+        // Inflate path: reassemble the payload (the 5 header bytes already read plus the
+        // remainder) into `compressed_buffer` and decompress it with libdeflate.
+        self.compressed_buffer[..DEFLATE_STORED_HEADER_SIZE].copy_from_slice(&deflate_header);
+        self.reader
+            .read_exact(&mut self.compressed_buffer[DEFLATE_STORED_HEADER_SIZE..payload_len])?;
+
+        let compressed = &self.compressed_buffer[..payload_len];
+        let check = get_footer_values(compressed);
+        let decompressed_len = check.amount as usize;
+
+        // The decompressed buffer is sized to the BGZF maximum; a block claiming more is
+        // corrupt and would otherwise index out of bounds.
+        if decompressed_len > self.decompressed_buffer.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                BgzfError::UncompressedSizeExceeded {
+                    found: decompressed_len,
+                    max: self.decompressed_buffer.len(),
+                },
+            ));
+        }
+
+        self.decompressor
+            .decompress(
+                strip_footer(compressed),
+                &mut self.decompressed_buffer[..decompressed_len],
+                check,
+                self.validate_crc,
+            )
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        self.block_pos = 0;
+        self.block_end = decompressed_len;
+        Ok(true)
+    }
 }
 
 impl Reader<File> {
@@ -150,100 +251,39 @@ where
 
             debug_assert!(total_bytes_copied < buf.len(), "More bytes copied than requested.");
 
-            // Read the 18-byte BGZF header together with the 5-byte DEFLATE block header. Reading
-            // both at once lets us choose the stored fast path without a second read: a clean EOF
-            // at a block boundary stops the stream, while a partial read signals a truncated block.
-            if !read_full(&mut self.reader, &mut self.header_buffer)? {
+            if !self.fetch_next_block()? {
                 break; // clean EOF
             }
-            check_header(&self.header_buffer[..BGZF_HEADER_SIZE])
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-
-            // A valid block always holds at least a header and footer; anything smaller is a
-            // corrupt header and would underflow `payload_len`.
-            let block_size = get_block_size(&self.header_buffer[..BGZF_HEADER_SIZE]);
-            if block_size < BGZF_HEADER_SIZE + BGZF_FOOTER_SIZE {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    BgzfError::InvalidHeader("block size smaller than header plus footer"),
-                ));
-            }
-            let payload_len = block_size - BGZF_HEADER_SIZE;
-
-            // The 5 bytes after the BGZF header are the DEFLATE block header. Copy them out so we
-            // can both inspect them and, on the inflate path, prepend them to the payload.
-            let deflate_header: [u8; DEFLATE_STORED_HEADER_SIZE] = self.header_buffer
-                [BGZF_HEADER_SIZE..]
-                .try_into()
-                .expect("header_buffer holds the DEFLATE block header");
-
-            // Fast path: a single final stored block that spans the whole payload holds its bytes
-            // verbatim. Read the data and its footer straight into the decompressed buffer (at
-            // offset 0, so callers drain an aligned, contiguous slice), skipping libdeflate and any
-            // staging copy, then verify the uncompressed size and CRC.
-            if let Some(len) = stored_block_len(&deflate_header) {
-                let with_footer = len + BGZF_FOOTER_SIZE;
-                if payload_len == DEFLATE_STORED_HEADER_SIZE + with_footer
-                    && with_footer <= self.decompressed_buffer.len()
-                {
-                    self.reader.read_exact(&mut self.decompressed_buffer[..with_footer])?;
-                    let check = get_footer_values(&self.decompressed_buffer[..with_footer]);
-                    if check.amount as usize != len {
-                        return Err(io::Error::new(
-                            io::ErrorKind::Other,
-                            BgzfError::InvalidHeader("stored block length disagrees with footer"),
-                        ));
-                    }
-                    if self.validate_crc {
-                        let found = crc32(&self.decompressed_buffer[..len]);
-                        if found != check.sum {
-                            return Err(io::Error::new(
-                                io::ErrorKind::Other,
-                                BgzfError::InvalidChecksum { found, expected: check.sum },
-                            ));
-                        }
-                    }
-                    self.block_pos = 0;
-                    self.block_end = len;
-                    continue;
-                }
-            }
-
-            // Inflate path: reassemble the payload (the 5 header bytes already read plus the
-            // remainder) into `compressed_buffer` and decompress it with libdeflate.
-            self.compressed_buffer[..DEFLATE_STORED_HEADER_SIZE].copy_from_slice(&deflate_header);
-            self.reader
-                .read_exact(&mut self.compressed_buffer[DEFLATE_STORED_HEADER_SIZE..payload_len])?;
-
-            let compressed = &self.compressed_buffer[..payload_len];
-            let check = get_footer_values(compressed);
-            let decompressed_len = check.amount as usize;
-
-            // The decompressed buffer is sized to the BGZF maximum; a block claiming more is
-            // corrupt and would otherwise index out of bounds.
-            if decompressed_len > self.decompressed_buffer.len() {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    BgzfError::UncompressedSizeExceeded {
-                        found: decompressed_len,
-                        max: self.decompressed_buffer.len(),
-                    },
-                ));
-            }
-
-            self.decompressor
-                .decompress(
-                    strip_footer(compressed),
-                    &mut self.decompressed_buffer[..decompressed_len],
-                    check,
-                    self.validate_crc,
-                )
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-            self.block_pos = 0;
-            self.block_end = decompressed_len;
         }
 
         Ok(total_bytes_copied)
+    }
+}
+
+impl<R> BufRead for Reader<R>
+where
+    R: Read,
+{
+    /// Return the current block's unread decompressed bytes, decoding the next block when the
+    /// current one is exhausted.
+    ///
+    /// Empty blocks (e.g. the BGZF EOF marker) are skipped; an empty returned slice means end of
+    /// input. Implementing [`BufRead`] lets callers use [`read_until`](BufRead::read_until),
+    /// [`lines`](BufRead::lines), etc., and borrow the reader's decompressed buffer directly rather
+    /// than wrapping it in a `BufReader` — which would redundantly copy already-decompressed bytes
+    /// into a second buffer.
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        // Advance past any exhausted or empty blocks until data is available or the stream ends.
+        while self.block_pos == self.block_end {
+            if !self.fetch_next_block()? {
+                break; // clean EOF; the (empty) current block is returned below
+            }
+        }
+        Ok(&self.decompressed_buffer[self.block_pos..self.block_end])
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.block_pos = (self.block_pos + amt).min(self.block_end);
     }
 }
 


### PR DESCRIPTION
## Summary

`Reader` already buffers a full decompressed block internally but only exposed `Read`, while
`MultithreadedReader` implemented `BufRead` — an inconsistency. This adds `BufRead` to `Reader`
so both readers offer the same interface.

Value: unlocks `read_until` / `lines` / `split`, and — more importantly — lets callers **borrow
the reader's decompressed block buffer directly** instead of wrapping it in a `BufReader` (which
would redundantly copy already-decompressed bytes into a second buffer). Downstream code taking
`impl BufRead` (common in the bioinformatics record-parser ecosystem) can now accept the reader
directly.

## Reviewing note: `reader.rs` is mostly *moved* code

The `reader.rs` diff-stat looks large, but the bulk is **code movement**, not new logic:
- The per-block read+decode loop body was factored out of `Read::read` into a private
  `fetch_next_block()` helper, shared by `read()` and the new `fill_buf()`.
- `read()`'s behavior is unchanged — it just calls the helper now (the existing round-trip
  proptest and all prior tests pass untouched).

The genuinely **new** code is small:
- `impl BufRead for Reader` — `fill_buf` (skips empty blocks like the EOF marker; empty slice = EOF)
  and `consume`.
- 4 new tests: `lines()`, `read_until`, manual `fill_buf`/`consume` across a multi-block store-only
  stream, and empty-stream.
- CHANGELOG entry.

## Notes

- Additive, non-breaking → next release can be a patch (0.4.1).
- Gate green: fmt, clippy (default + `--all-features`), `cargo doc -D warnings`, tests
  (26+7 default, 46+9 all-features).