### PR TITLE
fix(writer): don't re-enter a failed sink when finalizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of wrapping the reader in a `BufReader` (which would redundantly re-buffer already
   decompressed bytes).
 
+### Fixed
+- `Writer` no longer re-enters an already-failed sink when finalizing. Previously, once a `write` or `flush` had failed (e.g. the sink returned `BrokenPipe`), a subsequent `Drop` or `finish()` would still try to flush buffered blocks and write the BGZF EOF marker onto the broken stream — swallowing the error (silent truncation for code relying on `Drop`), and, for a sink that blocks after failing, deadlocking. `Writer` now tracks a poisoned state: `write`/`flush` fail fast once the sink has failed, and `finish()`/`Drop` skip all finalization instead of re-entering it. The healthy path is unchanged — a normal writer still emits the EOF marker exactly once.
+
 ## [0.4.0] - 2026-07-04
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -811,6 +811,106 @@ mod test {
         assert_eq!(eof_count, 1, "EOF marker should appear exactly once");
     }
 
+    /// A sink that fails its first `write` with `BrokenPipe` and then blocks forever on any later
+    /// call — modelling a buffered sink that deadlocks if re-entered after returning an error. Used
+    /// to prove `Writer::drop` does not re-enter a sink that has already failed.
+    struct FailThenBlockSink {
+        writes: usize,
+    }
+
+    impl Write for FailThenBlockSink {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            self.writes += 1;
+            if self.writes == 1 {
+                return Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "broken pipe"));
+            }
+            // Any re-entry after the failure parks forever; a loop guards spurious wake-ups.
+            loop {
+                std::thread::park();
+            }
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            loop {
+                std::thread::park();
+            }
+        }
+    }
+
+    /// Drive `writer` until a block is emitted (surfacing the sink's `BrokenPipe`), then run
+    /// `finalize` on it on a worker thread. Returns whether finalization completed within the
+    /// watchdog window — `false` means it re-entered the now-blocking sink and hung. Covers both
+    /// finalization paths that could re-enter the sink: `Drop` and `finish`.
+    fn finalize_returns_after_sink_failure(
+        mut writer: Writer<FailThenBlockSink>,
+        finalize: impl FnOnce(Writer<FailThenBlockSink>) + Send + 'static,
+    ) -> bool {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            // Several blocks' worth of data: emitting the first block hits the sink, which fails
+            // and leaves later blocks still buffered.
+            let err = writer.write_all(&[b'A'; 4096]).unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe);
+            // Finalizing the now-poisoned writer must NOT re-enter the blocking sink.
+            finalize(writer);
+            let _ = tx.send(());
+        });
+
+        rx.recv_timeout(Duration::from_secs(5)).is_ok()
+    }
+
+    /// On the compress path, dropping a writer whose sink already failed must return immediately
+    /// rather than re-entering the broken (and here, blocking) sink to flush blocks and write EOF.
+    #[test]
+    fn drop_does_not_reenter_a_failed_sink() {
+        // Small block size so a modest write forces a block emission, and thus a sink write.
+        let writer = Writer::with_capacity(
+            FailThenBlockSink { writes: 0 },
+            CompressionLevel::new(6).unwrap(),
+            1024,
+        );
+        assert!(
+            finalize_returns_after_sink_failure(writer, drop),
+            "Writer::drop re-entered a broken sink and hung"
+        );
+    }
+
+    /// The store-only (level 0) path emits blocks through a separate code path; its `Drop` must be
+    /// equally defensive about not re-entering a sink that has already failed.
+    #[test]
+    fn store_only_drop_does_not_reenter_a_failed_sink() {
+        let writer = Writer::with_capacity(
+            FailThenBlockSink { writes: 0 },
+            CompressionLevel::new(0).unwrap(),
+            1024,
+        );
+        assert!(
+            finalize_returns_after_sink_failure(writer, drop),
+            "store-only Writer::drop re-entered a broken sink and hung"
+        );
+    }
+
+    /// Calling `finish()` after a write already failed is a plausible best-effort cleanup pattern;
+    /// like `Drop`, it must not re-enter the broken (blocking) sink to flush blocks or write EOF.
+    #[test]
+    fn finish_does_not_reenter_a_failed_sink() {
+        let writer = Writer::with_capacity(
+            FailThenBlockSink { writes: 0 },
+            CompressionLevel::new(6).unwrap(),
+            1024,
+        );
+        assert!(
+            finalize_returns_after_sink_failure(writer, |w| {
+                // finish() consumes the writer; the returned error is expected and ignored here.
+                let _ = w.finish();
+            }),
+            "Writer::finish re-entered a broken sink and hung"
+        );
+    }
+
     /// Assert that a reader error wraps a [`BgzfError`] matching `want`.
     fn assert_bgzf_err(result: std::io::Result<usize>, want: impl Fn(&BgzfError) -> bool) {
         let err = result.expect_err("expected an error");

--- a/src/multithreaded_writer.rs
+++ b/src/multithreaded_writer.rs
@@ -485,6 +485,57 @@ mod tests {
         assert_eq!(decode(&compressed), input);
     }
 
+    /// Dropping the writer after its sink has failed must return promptly, never re-entering (and
+    /// so never hanging on) the broken sink. Unlike the single-threaded `Writer`, this falls out of
+    /// the architecture for free: the sink lives on the writer thread, which drops it the instant a
+    /// write errors, and `Drop` only joins threads — it never touches the sink. This test guards
+    /// that property against a future refactor that reintroduces sink access on the finalize path.
+    #[test]
+    fn drop_returns_promptly_after_sink_failure() {
+        // Fails its first write, then parks forever on any later call. If `Drop` re-entered the
+        // sink after the failure, the join in `finish` would deadlock on that park.
+        struct FailThenBlockSink {
+            writes: usize,
+        }
+        impl Write for FailThenBlockSink {
+            fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+                self.writes += 1;
+                if self.writes == 1 {
+                    return Err(io::Error::new(io::ErrorKind::BrokenPipe, "broken pipe"));
+                }
+                loop {
+                    thread::park();
+                }
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                loop {
+                    thread::park();
+                }
+            }
+        }
+
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            let mut writer = MultithreadedWriter::with_capacity(
+                NonZero::new(2).unwrap(),
+                FailThenBlockSink { writes: 0 },
+                level(6),
+                1024,
+            );
+            let _ = writer.write_all(&[b'A'; 4096]);
+            drop(writer);
+            let _ = tx.send(());
+        });
+
+        assert!(
+            rx.recv_timeout(Duration::from_secs(5)).is_ok(),
+            "MultithreadedWriter::drop hung after the sink failed"
+        );
+    }
+
     use proptest::prelude::*;
 
     proptest! {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -58,6 +58,10 @@ where
     store_data_len: usize,
     /// The inner writer, wrapped in Option to allow taking ownership in finish()
     writer: Option<W>,
+    /// Set to true once any write or flush to the inner writer has failed. A poisoned writer
+    /// refuses further writes, and — crucially — its `Drop` will not re-enter the (already broken,
+    /// possibly blocking) sink to flush buffered blocks or emit the EOF marker.
+    poisoned: bool,
 }
 
 impl<W> Writer<W>
@@ -97,6 +101,7 @@ where
             store_crc: Crc::new(),
             store_data_len: 0,
             writer: Some(writer),
+            poisoned: false,
         }
     }
 
@@ -108,10 +113,19 @@ where
     /// the EOF marker will be written when the writer is dropped, but any
     /// errors will be silently ignored.
     pub fn finish(mut self) -> io::Result<W> {
+        // A prior write/flush already broke the sink; do not re-enter it to flush buffered blocks
+        // or write EOF — that would write onto a dead stream and, for a sink that blocks after
+        // failing, deadlock here. Returning early leaves `self.writer` set and `poisoned` true, so
+        // the ensuing Drop also skips finalization.
+        if self.poisoned {
+            return Err(poisoned_error());
+        }
         self.flush_buffer()?;
         let mut writer = self.writer.take().expect("writer already taken");
-        writer.write_all(BGZF_EOF)?;
-        writer.flush()?;
+        if let Err(e) = writer.write_all(BGZF_EOF).and_then(|()| writer.flush()) {
+            self.poisoned = true;
+            return Err(e);
+        }
         Ok(writer)
     }
 
@@ -136,7 +150,10 @@ where
             self.compressor
                 .compress(&b[..], &mut self.compressed_buffer)
                 .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-            writer.write_all(&self.compressed_buffer)?;
+            if let Err(e) = writer.write_all(&self.compressed_buffer) {
+                self.poisoned = true;
+                return Err(e);
+            }
             self.compressed_buffer.clear();
         }
         Ok(())
@@ -190,7 +207,10 @@ where
             .writer
             .as_mut()
             .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "writer already finished"))?;
-        writer.write_all(&self.compressed_buffer[..end])?;
+        if let Err(e) = writer.write_all(&self.compressed_buffer[..end]) {
+            self.poisoned = true;
+            return Err(e);
+        }
 
         self.store_crc = Crc::new();
         self.store_data_len = 0;
@@ -228,6 +248,11 @@ where
 {
     /// Write a buffer into this writer, returning how many bytes were written.
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        // A prior write/flush already failed; refuse to buffer more rather than accumulate data
+        // that can never be flushed (Drop deliberately skips a poisoned sink).
+        if self.poisoned {
+            return Err(poisoned_error());
+        }
         if self.store_only {
             if self.writer.is_none() {
                 return Err(io::Error::new(io::ErrorKind::Other, "writer already finished"));
@@ -244,7 +269,10 @@ where
             self.compressor
                 .compress(&b[..], &mut self.compressed_buffer)
                 .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-            writer.write_all(&self.compressed_buffer)?;
+            if let Err(e) = writer.write_all(&self.compressed_buffer) {
+                self.poisoned = true;
+                return Err(e);
+            }
             self.compressed_buffer.clear();
         }
         Ok(buf.len())
@@ -255,9 +283,15 @@ where
     /// Note: This does NOT write the BGZF EOF marker. Call [`Writer::finish`] when
     /// you are done writing to properly finalize the BGZF file.
     fn flush(&mut self) -> std::io::Result<()> {
+        if self.poisoned {
+            return Err(poisoned_error());
+        }
         self.flush_buffer()?;
         if let Some(writer) = self.writer.as_mut() {
-            writer.flush()?;
+            if let Err(e) = writer.flush() {
+                self.poisoned = true;
+                return Err(e);
+            }
         }
         Ok(())
     }
@@ -268,15 +302,29 @@ where
     W: Write,
 {
     fn drop(&mut self) {
-        // Only write EOF if finish() wasn't called (writer is still Some)
-        if self.writer.is_some() {
-            // Flush buffer first (this borrows self mutably)
-            let _ = self.flush_buffer();
-            // Now we can borrow writer
-            if let Some(ref mut writer) = self.writer {
-                let _ = writer.write_all(BGZF_EOF);
-                let _ = writer.flush();
-            }
+        // Finalize only a healthy, un-finished writer. If `finish()` already took the writer, or a
+        // prior write/flush poisoned it, there is nothing to finalize: re-entering an already
+        // broken sink would write an EOF marker onto a dead stream, silently swallow the resulting
+        // error, and — for a sink that blocks after failing — deadlock here during unwinding.
+        if self.writer.is_none() || self.poisoned {
+            return;
+        }
+        // Flush buffer first (this borrows self mutably). If it fails it poisons the writer, so
+        // re-check before re-entering the sink to write EOF — otherwise a sink that broke mid-flush
+        // would be re-entered here.
+        let _ = self.flush_buffer();
+        if self.poisoned {
+            return;
+        }
+        if let Some(ref mut writer) = self.writer {
+            let _ = writer.write_all(BGZF_EOF);
+            let _ = writer.flush();
         }
     }
+}
+
+/// The error returned when a write or flush is attempted on a writer whose inner sink already
+/// failed. The writer cannot recover — its buffered block state is inconsistent — so it fails fast.
+fn poisoned_error() -> io::Error {
+    io::Error::new(io::ErrorKind::Other, "bgzf writer poisoned by an earlier write failure")
 }


### PR DESCRIPTION
## What this fixes

`Writer`'s `Drop` unconditionally re-entered the underlying sink during finalization — it flushed any buffered blocks and wrote the BGZF EOF marker — **even when a prior `write`/`flush` had already failed**. When the sink was broken (e.g. it returned `BrokenPipe`), this had three bad consequences:

1. An EOF marker written onto an already-dead stream.
2. Silent truncation: the finalization error was swallowed (`let _ = ...`), so code relying on `Drop` instead of `finish()` never learned the stream was incomplete.
3. **Deadlock**: a sink that blocks after returning an error (a real footgun with misbehaving buffered sinks) would hang forever inside `Drop`, during unwinding.

`finish()` had the same re-entry hazard on a poisoned writer.

## The change (diff vs `main`)

- Add a `poisoned: bool` field to `Writer`, set to `true` the moment any sink `write_all`/`flush` fails — across every sink-facing call site (`write`, `flush`, `flush_buffer`, `emit_store_block`, `finish`), on both the compress and store-only (level 0) paths.
- `write()` and `flush()` fail fast if already poisoned rather than continuing to buffer data that can never be flushed.
- `finish()` returns early (without touching the sink) if poisoned.
- `Drop` skips **all** finalization when the writer was already finished (`finish()` took it) or is poisoned; it also re-checks `poisoned` after its own `flush_buffer()` so a sink that breaks mid-finalization isn't re-entered for the EOF write.
- The healthy success path is unchanged: a normal writer still emits the BGZF EOF marker exactly once, byte-for-byte as before (the `poisoned` flag only ever flips on a real sink failure).

## Tests

- `drop_does_not_reenter_a_failed_sink` and `store_only_drop_does_not_reenter_a_failed_sink` — a sink that fails its first write with `BrokenPipe` then parks forever; the writer is dropped on a worker thread guarded by a 5s watchdog. These hang (and fail) against the pre-fix `Drop`; they return immediately with the fix.
- `finish_does_not_reenter_a_failed_sink` — same, for the best-effort "write failed, still call `finish()` for cleanup" pattern.
- `drop_returns_promptly_after_sink_failure` (multithreaded) — `MultithreadedWriter` is **not** affected by this bug: its sink lives on a dedicated writer thread that drops it on the first error and is only ever joined, never re-entered. This test guards that property against a future refactor.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --all-features --all-targets -- -D warnings`, and `cargo test --all-features` all pass (50 unit + 9 doc tests).