### PR TITLE
fix(mt-writer): surface the real error from finish() on a broken sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `Writer` no longer re-enters an already-failed sink when finalizing. Previously, once a `write` or `flush` had failed (e.g. the sink returned `BrokenPipe`), a subsequent `Drop` or `finish()` would still try to flush buffered blocks and write the BGZF EOF marker onto the broken stream — swallowing the error (silent truncation for code relying on `Drop`), and, for a sink that blocks after failing, deadlocking. `Writer` now tracks a poisoned state: `write`/`flush` fail fast once the sink has failed, and `finish()`/`Drop` skip all finalization instead of re-entering it. The healthy path is unchanged — a normal writer still emits the EOF marker exactly once.
+- `MultithreadedWriter::finish()` now surfaces the writer thread's real I/O error. Previously, if the sink had already failed and a partial block was still buffered, `finish()` returned early on the failed dispatch with a generic "bgzf writer pipeline stopped" error — masking the real underlying error (which only leaked out via a second `finish()` call) and leaving the writer in the `Running` state so a later `Drop` silently re-ran finalization. `finish()` now always drains and joins the worker pool (leaving the writer `Done`) and reports the most informative error: the writer thread's own failure ahead of a deflater panic or a failed final dispatch. As part of this, a panicking deflater thread no longer leaves the writer thread detached.
 
 ## [0.4.0] - 2026-07-04
 

--- a/src/multithreaded_writer.rs
+++ b/src/multithreaded_writer.rs
@@ -159,20 +159,36 @@ where
     /// `Drop` path would silently swallow, and guarantees the EOF marker is written exactly
     /// once.
     pub fn finish(&mut self) -> io::Result<W> {
-        if !self.buf.is_empty() {
-            self.send()?;
-        }
+        // Dispatch any final buffered block, but do NOT bail out on failure: a failed dispatch
+        // means the pipeline has already broken, and the writer thread holds the *real* error
+        // (e.g. the underlying I/O failure). We always drain and join every thread below — both to
+        // surface that error and to leave the writer in the `Done` state, so a later `Drop` can't
+        // silently re-run finalization and swallow it.
+        let send_result = self.send();
+
         match std::mem::replace(&mut self.state, State::Done) {
             State::Running { writer_handle, mut deflater_handles, deflate_tx, order_tx } => {
-                // Close the deflater input so workers finish once they have drained it, then
-                // join them. Closing the order channel afterwards lets the writer thread
-                // drain its queue, append EOF, and return the inner writer.
+                // Close the deflater input so workers finish once they have drained it, and join
+                // them all. Record a panic rather than returning early on it: we must still close
+                // the order channel and join the writer thread so it is never left detached. That
+                // close then lets the writer thread drain its queue, append EOF, and hand back the
+                // inner writer.
                 drop(deflate_tx);
+                let mut deflater_panicked = false;
                 for handle in deflater_handles.drain(..) {
-                    handle.join().map_err(|_| thread_panicked("deflater"))?;
+                    deflater_panicked |= handle.join().is_err();
                 }
                 drop(order_tx);
-                writer_handle.join().map_err(|_| thread_panicked("writer"))?
+                let writer_result = writer_handle.join().map_err(|_| thread_panicked("writer"))?;
+
+                // Error precedence, most informative first: the writer thread's own I/O/compression
+                // failure, then a deflater panic, then a failed final dispatch. A clean writer exit
+                // implies the others succeeded too, so the later checks are safety nets.
+                let writer = writer_result?;
+                if deflater_panicked {
+                    return Err(thread_panicked("deflater"));
+                }
+                send_result.map(|()| writer)
             }
             State::Done => Err(io::Error::new(io::ErrorKind::Other, "writer already finished")),
         }
@@ -533,6 +549,49 @@ mod tests {
         assert!(
             rx.recv_timeout(Duration::from_secs(5)).is_ok(),
             "MultithreadedWriter::drop hung after the sink failed"
+        );
+    }
+
+    /// A sink whose every write fails with a distinctive error, modelling a persistently broken
+    /// destination (e.g. a full disk). The message lets tests tell the *real* error apart from a
+    /// generic pipeline-stopped placeholder.
+    #[derive(Debug)]
+    struct AlwaysFailSink;
+    impl Write for AlwaysFailSink {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(io::ErrorKind::Other, "disk full"))
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// When the sink has already failed and a partial block is still buffered, `finish()` must
+    /// surface the writer thread's real I/O error — not a generic "pipeline stopped" placeholder —
+    /// and must leave the writer finished so a second call reports "already finished" rather than
+    /// re-running (which is how the real error used to leak out only on the second call).
+    #[test]
+    fn finish_surfaces_real_error_when_block_buffered() {
+        let mut w = MultithreadedWriter::with_capacity(
+            NonZero::new(2).unwrap(),
+            AlwaysFailSink,
+            level(6),
+            1024,
+        );
+        // Enough full blocks to overflow the pipeline so the writer thread exits on the sink error
+        // and the caller's writes begin to fail.
+        assert!(w.write_all(&[0u8; 1024 * 50]).is_err());
+        // A sub-block write only buffers locally (no dispatch, since it stays under blocksize), so
+        // a partial block is pending at finish time — the case that used to mask the real error.
+        w.write_all(&[0u8; 100]).unwrap();
+
+        let first = w.finish().unwrap_err();
+        assert_eq!(first.to_string(), "disk full", "finish() must surface the real sink error");
+
+        let second = w.finish().unwrap_err();
+        assert!(
+            second.to_string().contains("already finished"),
+            "after finish() the writer must be Done, got: {second}"
         );
     }
 


### PR DESCRIPTION
## What this fixes

`MultithreadedWriter::finish()` dispatched any final buffered block via `self.send()?` **before** transitioning `state` to `Done`. When the sink had already failed — the dedicated writer thread hit an I/O error, exited, and dropped its receiver — and a partial block was still buffered, that `send()` failed with a generic `"bgzf writer pipeline stopped"` error and `finish()` returned early. Two consequences:

1. **The real error was masked.** The writer thread's actual I/O error (e.g. "No space left on device") was never surfaced — it was only retrievable by calling `finish()` a *second* time, which no caller does. This defeats the method's documented purpose ("surfaces compression and I/O errors that the `Drop` path would silently swallow").
2. **State was left `Running`.** Because the early return skipped the `mem::replace(..., Done)`, a subsequent `Drop` silently re-ran finalization and swallowed the real error.

## The change (diff vs `main`)

- `finish()` captures the final-dispatch result (`let send_result = self.send();`) instead of `?`-returning on it, then **always** runs the `Done` transition and drains + joins the worker pool. It reports the most informative error, in precedence order: the **writer thread's own failure** → a deflater panic → a failed final dispatch. In practice a clean writer exit implies the others succeeded, so the latter two are safety nets.
- Joining is now panic-safe: a panicking deflater thread is recorded rather than early-returned on, so the order channel is still closed and the writer thread is still joined — previously a deflater panic left the writer thread *detached* and the recovered inner writer lost.
- The healthy path is unchanged: `send()` already no-ops on an empty buffer, so replacing `if !buf.is_empty() { send()? }` with an unconditional `send()` is behaviorally identical, and the EOF marker is still written exactly once.

## Tests

- `finish_surfaces_real_error_when_block_buffered` — a sink that always fails with a distinctive `"disk full"` error, driven until the pipeline breaks with a partial block still buffered. Asserts `finish()` returns the real `"disk full"` (not the generic placeholder) and that a second `finish()` reports `"already finished"` (proving `state` is left `Done`). It fails against the pre-fix code (`"bgzf writer pipeline stopped"`) and passes after.

## Scope note

This does not attempt to prevent data loss of in-flight blocks when the sink dies mid-stream — that output is already truncated/invalid by definition, and the fix's job is to *report* the failure faithfully, not to recover an unrecoverable stream.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --all-features --all-targets -- -D warnings`, and `cargo test --all-features` all pass (47 unit + 9 doc tests). The new test was additionally run 160+ times (debug/release, sequential and concurrent) with zero failures to confirm it is deterministic, not racy.